### PR TITLE
MULE-12608: Remove com.google.common from exported packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,11 @@
             <artifactId>commons-io</artifactId>
             <version>${commonsIoVersion}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guavaVersion}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.mule.tests</groupId>


### PR DESCRIPTION
_ Fixing tests