### PR TITLE
MULE-12973: Add support for start parameter in http multipart/related…

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/HttpMultipartEncoder.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/HttpMultipartEncoder.java
@@ -6,7 +6,9 @@
  */
 package org.mule.service.http.impl.service.server.grizzly;
 
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_DISPOSITION;
+import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_ID;
 import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_TYPE;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.core.api.util.IOUtils;
@@ -33,9 +35,23 @@ public class HttpMultipartEncoder {
 
   private static final String FORM_DATA = "form-data";
   public static final String ATTACHMENT = "attachment";
+  private static final String RELATED = "related";
+  private static final String TYPE_PARAMETER = "type";
+  private static final String START_PARAMETER = "start";
+  public static final String MANDATORY_TYPE_ERROR_MESSAGE =
+      "Type parameter is not present in multipart/related content type, but it is mandatory.";
+  public static final String AMBIGUOUS_TYPE_ERROR_MESSAGE = "Type parameter and root body part content type must be the same.";
+
+  private HttpMultipartEncoder() {}
 
   public static MimeMultipart toMimeMultipart(HttpEntity body, String contentType) throws IOException {
     String contentTypeSubType = getContentTypeSubType(contentType);
+    String typeParameter = getContentTypeParameter(contentType, TYPE_PARAMETER);
+
+    if (contentTypeSubType.equals(RELATED) && typeParameter == null) {
+      throw new MuleRuntimeException(createStaticMessage(MANDATORY_TYPE_ERROR_MESSAGE));
+    }
+
     MimeMultipart mimeMultipartContent = new HttpMimeMultipart(contentType, contentTypeSubType);
     final Collection<HttpPart> parts = body.getParts();
 
@@ -51,17 +67,40 @@ public class HttpMultipartEncoder {
         String partType = contentTypeSubType.equals(FORM_DATA) ? FORM_DATA : ATTACHMENT;
         internetHeaders.addHeader(CONTENT_DISPOSITION, getContentDisposition(part, partType));
       }
+      if (contentTypeSubType.equals(RELATED) && part.getName() != null) {
+        internetHeaders.addHeader(CONTENT_ID, part.getName());
+      }
       if (internetHeaders.getHeader(CONTENT_TYPE) == null && part.getContentType() != null) {
         internetHeaders.addHeader(CONTENT_TYPE, part.getContentType());
       }
       try {
         // TODO: MULE-12827 - Support HTTP multipart streaming
         final byte[] partContent = IOUtils.toByteArray(part.getInputStream());
-        mimeMultipartContent.addBodyPart(new MimeBodyPart(internetHeaders, partContent));
+
+        String rootContentId = getContentTypeParameter(contentType, START_PARAMETER);
+
+        if (contentTypeSubType.equals(RELATED) && part.getName() != null && part.getName().equals(rootContentId)) {
+          mimeMultipartContent.addBodyPart(new MimeBodyPart(internetHeaders, partContent), 0);
+        } else {
+          mimeMultipartContent.addBodyPart(new MimeBodyPart(internetHeaders, partContent));
+        }
+
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw new MuleRuntimeException(e);
       }
     }
+
+    try {
+      if (contentTypeSubType.equals(RELATED) && mimeMultipartContent.getCount() > 0) {
+        String rootBodyPartContentType = mimeMultipartContent.getBodyPart(0).getContentType();
+        if (rootBodyPartContentType != null && (!rootBodyPartContentType.equals(typeParameter))) {
+          throw new MuleRuntimeException(createStaticMessage(AMBIGUOUS_TYPE_ERROR_MESSAGE));
+        }
+      }
+    } catch (MessagingException e) {
+      throw new MuleRuntimeException(e);
+    }
+
     return mimeMultipartContent;
   }
 
@@ -106,4 +145,21 @@ public class HttpMultipartEncoder {
     }
     return builder.toString();
   }
+
+  /**
+   * Extracts a parameter value from a content type
+   *
+   * @param contentType the content type
+   * @param parameterName: the name of the parameter to extract.
+   * @return the value of the extracted parameter.
+   */
+  public static String getContentTypeParameter(String contentType, String parameterName) {
+    try {
+      ContentType contentTypeValue = new ContentType(contentType);
+      return contentTypeValue.getParameter(parameterName);
+    } catch (ParseException e) {
+      throw new MuleRuntimeException(e);
+    }
+  }
+
 }

--- a/src/test/java/org/mule/service/http/impl/service/server/grizzly/HttpMultipartEncoderTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/server/grizzly/HttpMultipartEncoderTestCase.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.service.http.impl.service.server.grizzly;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_ID;
+import static org.mule.service.http.impl.service.server.grizzly.HttpMultipartEncoder.AMBIGUOUS_TYPE_ERROR_MESSAGE;
+import static org.mule.service.http.impl.service.server.grizzly.HttpMultipartEncoder.MANDATORY_TYPE_ERROR_MESSAGE;
+import static org.mule.service.http.impl.service.server.grizzly.HttpMultipartEncoder.toMimeMultipart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.mail.BodyPart;
+import javax.mail.internet.MimeMultipart;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mule.runtime.http.api.domain.entity.HttpEntity;
+import org.mule.runtime.http.api.domain.entity.multipart.HttpPart;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+public class HttpMultipartEncoderTestCase extends AbstractMuleTestCase {
+
+  private static final String FIRST_PART_CONTENT = "first-part-test";
+
+  private static final String SECOND_PART_CONTENT = "second-part-test";
+
+  private static final String THIRD_PART_CONTENT = "third-part-test";
+
+  private static final String FORTH_PART_CONTENT = "{ \"test\" : \"forth-part-test\"}";
+
+  private final List<HttpPart> httpParts = new ArrayList<>();
+
+  private final HttpEntity httpEntity = mock(HttpEntity.class);
+
+  @Before
+  public void setUp() throws Exception {
+    HttpPart firstPart =
+        new HttpPart("firstPart", FIRST_PART_CONTENT.getBytes(), "text/plain", FIRST_PART_CONTENT.getBytes().length);
+    httpParts.add(firstPart);
+
+    HttpPart secondPart =
+        new HttpPart("secondPart", SECOND_PART_CONTENT.getBytes(), "text/plain", SECOND_PART_CONTENT.getBytes().length);
+    httpParts.add(secondPart);
+
+    HttpPart thirdPart =
+        new HttpPart("thirdPart", THIRD_PART_CONTENT.getBytes(), "text/plain", THIRD_PART_CONTENT.getBytes().length);
+    httpParts.add(thirdPart);
+
+    when(httpEntity.getParts()).thenReturn(httpParts);
+  }
+
+  @Test
+  public void createMultipartRelatedContentWithStartParameter() throws Exception {
+    MimeMultipart mimeMultipart =
+        toMimeMultipart(httpEntity, "multipart/related; boundary= \"MIMEBoundary\"; type=\"text/plain\"; start=thirdPart");
+    verifyBodyPart(mimeMultipart.getBodyPart(0), THIRD_PART_CONTENT, "thirdPart");
+    verifyBodyPart(mimeMultipart.getBodyPart(1), FIRST_PART_CONTENT, "firstPart");
+    verifyBodyPart(mimeMultipart.getBodyPart(2), SECOND_PART_CONTENT, "secondPart");
+    assertThat(mimeMultipart.getContentType(), containsString("type=\"text/plain\""));
+  }
+
+  @Test
+  public void createMultipartRelatedContentWithoutStartParameter() throws Exception {
+    MimeMultipart mimeMultipart =
+        toMimeMultipart(httpEntity, "multipart/related; boundary=\"MIMEBoundary\"; type=\"text/plain\";");
+    verifyBodyPart(mimeMultipart.getBodyPart(0), FIRST_PART_CONTENT, "firstPart");
+    verifyBodyPart(mimeMultipart.getBodyPart(1), SECOND_PART_CONTENT, "secondPart");
+    verifyBodyPart(mimeMultipart.getBodyPart(2), THIRD_PART_CONTENT, "thirdPart");
+    assertThat(mimeMultipart.getContentType(), containsString("type=\"text/plain\""));
+  }
+
+  @Test
+  public void createMultipartRelatedContentWithoutMandatoryTypeParameter() throws Exception {
+    try {
+      toMimeMultipart(httpEntity, "multipart/related; boundary=\"MIMEBoundary\"");
+      fail("Exception caused by no present type should be triggered");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), is(MANDATORY_TYPE_ERROR_MESSAGE));
+    }
+  }
+
+  @Test
+  public void createMultipartRelatedContentWithAmbiguousType() throws Exception {
+    HttpPart forthPart =
+        new HttpPart("forthPart", FORTH_PART_CONTENT.getBytes(), "application/json", FORTH_PART_CONTENT.getBytes().length);
+    httpParts.add(forthPart);
+    try {
+      toMimeMultipart(httpEntity, "multipart/related; boundary=\"MIMEBoundary\"; type=\"text/plain\"; start=forthPart");
+      fail("Exception caused by ambiguous type should be triggered");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), is(AMBIGUOUS_TYPE_ERROR_MESSAGE));
+    }
+  }
+
+  private void verifyBodyPart(BodyPart bodyPart, String content, String name) throws Exception {
+    assertThat(bodyPart.getContent(), is(content));
+    assertThat(bodyPart.getHeader(CONTENT_ID)[0], is(name));
+  }
+
+}


### PR DESCRIPTION
… response

According to this RFC article: https://tools.ietf.org/html/rfc2387, in multipart/related content type: The start parameter, if given, is the content-ID
of the compound object's "root". If not present the "root" is the first body part in the Multipart/Related entity. Additionally, we shoud also honor
the following restrictions:

- Type parameter is mandatory in multipart/related.
- The value of the content-type parameter must be the same that the root body part's content-type.