### PR TITLE
MULE-13034: Error responses with special characters should be scaped.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
+            <artifactId>commons-text</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,10 @@
             <artifactId>grizzly-websockets</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${commonsIoVersion}</version>

--- a/src/main/java/org/mule/service/http/impl/service/server/ErrorRequestHandler.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/ErrorRequestHandler.java
@@ -6,6 +6,7 @@
  */
 package org.mule.service.http.impl.service.server;
 
+import static java.lang.String.format;
 import org.mule.runtime.http.api.domain.entity.InputStreamHttpEntity;
 import org.mule.runtime.http.api.domain.message.response.HttpResponse;
 import org.mule.runtime.http.api.domain.request.HttpRequestContext;
@@ -24,7 +25,7 @@ public class ErrorRequestHandler implements RequestHandler {
 
   private int statusCode;
   private String reasonPhrase;
-  private String entityFormat;
+  protected String entityFormat;
 
   public ErrorRequestHandler(int statusCode, String reasonPhrase, String entityFormat) {
     this.statusCode = statusCode;
@@ -34,7 +35,7 @@ public class ErrorRequestHandler implements RequestHandler {
 
   @Override
   public void handleRequest(HttpRequestContext requestContext, HttpResponseReadyCallback responseCallback) {
-    String resolvedEntity = String.format(entityFormat, requestContext.getRequest().getUri());
+    String resolvedEntity = getResolvedEntity(requestContext.getRequest().getUri());
     responseCallback.responseReady(HttpResponse.builder()
         .setStatusCode(statusCode).setReasonPhrase(reasonPhrase)
         .setEntity(new InputStreamHttpEntity(new ByteArrayInputStream(resolvedEntity.getBytes()))).build(),
@@ -42,8 +43,8 @@ public class ErrorRequestHandler implements RequestHandler {
 
                                      @Override
                                      public void responseSendFailure(Throwable exception) {
-                                       logger.warn(String.format("Error while sending %s response %s", statusCode,
-                                                                 exception.getMessage()));
+                                       logger.warn(format("Error while sending %s response %s", statusCode,
+                                                          exception.getMessage()));
                                        if (logger.isDebugEnabled()) {
                                          logger.debug("exception thrown", exception);
                                        }
@@ -53,4 +54,9 @@ public class ErrorRequestHandler implements RequestHandler {
                                      public void responseSendSuccessfully() {}
                                    });
   }
+
+  protected String getResolvedEntity(String uri) {
+    return format(entityFormat, uri);
+  }
+
 }

--- a/src/main/java/org/mule/service/http/impl/service/server/NoListenerRequestHandler.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/NoListenerRequestHandler.java
@@ -7,7 +7,7 @@
 package org.mule.service.http.impl.service.server;
 
 import static java.lang.String.format;
-import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
+import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 import static org.mule.runtime.http.api.HttpConstants.HttpStatus.NOT_FOUND;
 
 /**
@@ -32,6 +32,5 @@ public class NoListenerRequestHandler extends ErrorRequestHandler {
   protected String getResolvedEntity(String uri) {
     return format(entityFormat, escapeHtml4(uri));
   }
-
 
 }

--- a/src/main/java/org/mule/service/http/impl/service/server/NoListenerRequestHandler.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/NoListenerRequestHandler.java
@@ -6,6 +6,8 @@
  */
 package org.mule.service.http.impl.service.server;
 
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
 import static org.mule.runtime.http.api.HttpConstants.HttpStatus.NOT_FOUND;
 
 /**
@@ -15,14 +17,21 @@ public class NoListenerRequestHandler extends ErrorRequestHandler {
 
   public static final String RESOURCE_NOT_FOUND = "Resource not found.";
 
+  public static final String NO_LISTENER_ENTITY_FORMAT = "No listener for endpoint: %s";
+
   private static NoListenerRequestHandler instance = new NoListenerRequestHandler();
 
   private NoListenerRequestHandler() {
-    super(NOT_FOUND.getStatusCode(), NOT_FOUND.getReasonPhrase(), "No listener for endpoint: %s");
+    super(NOT_FOUND.getStatusCode(), NOT_FOUND.getReasonPhrase(), NO_LISTENER_ENTITY_FORMAT);
   }
 
   public static NoListenerRequestHandler getInstance() {
     return instance;
   }
+
+  protected String getResolvedEntity(String uri) {
+    return format(entityFormat, escapeHtml4(uri));
+  }
+
 
 }

--- a/src/test/java/org/mule/service/http/impl/service/server/NoListenerRequestHandlerTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/server/NoListenerRequestHandlerTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.service.http.impl.service.server;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.service.http.impl.service.server.NoListenerRequestHandler.NO_LISTENER_ENTITY_FORMAT;
+
+import org.mule.runtime.core.api.util.IOUtils;
+import org.mule.runtime.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.runtime.http.api.domain.message.response.HttpResponse;
+import org.mule.runtime.http.api.domain.request.HttpRequestContext;
+import org.mule.runtime.http.api.server.async.HttpResponseReadyCallback;
+import org.mule.runtime.http.api.server.async.ResponseStatusCallback;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class NoListenerRequestHandlerTestCase extends AbstractMuleTestCase {
+
+  private final static String TEST_REQUEST_INVALID_URI = "http://localhost:8081/<script>alert('hello');</script>";
+  private final HttpRequestContext context = mock(HttpRequestContext.class, RETURNS_DEEP_STUBS);
+  private final HttpResponseReadyCallback responseReadyCallback = mock(HttpResponseReadyCallback.class);
+  private NoListenerRequestHandler noListenerRequestHandler;
+
+  @Before
+  public void setUp() throws Exception {
+    noListenerRequestHandler = NoListenerRequestHandler.getInstance();
+    when(context.getRequest().getUri()).thenReturn(TEST_REQUEST_INVALID_URI);
+  }
+
+  @Test
+  public void testInvalidEndpointWithSpecialCharacters() throws Exception {
+    final String[] result = new String[1];
+    doAnswer(invocation -> {
+      HttpResponse response = (HttpResponse) invocation.getArguments()[0];
+      InputStreamHttpEntity inputStreamHttpEntity = (InputStreamHttpEntity) response.getEntity();
+      result[0] = IOUtils.toString(inputStreamHttpEntity.getContent());
+      inputStreamHttpEntity.getContent().close();
+      return null;
+    }).when(responseReadyCallback).responseReady(any(HttpResponse.class), any(ResponseStatusCallback.class));
+    noListenerRequestHandler.handleRequest(context, responseReadyCallback);
+    assertThat(result[0], is(format(NO_LISTENER_ENTITY_FORMAT, escapeHtml4(TEST_REQUEST_INVALID_URI))));
+  }
+}

--- a/src/test/java/org/mule/service/http/impl/service/server/NoListenerRequestHandlerTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/server/NoListenerRequestHandlerTestCase.java
@@ -8,7 +8,7 @@
 package org.mule.service.http.impl.service.server;
 
 import static java.lang.String.format;
-import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
+import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;


### PR DESCRIPTION
Regarding to the following articles:

http://cwe.mitre.org/data/definitions/79.html
https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content

error responses with special characters should be scaped to avoid security vulnerabilities.