### PR TITLE
MULE-13831 Use shared reactor stream(s) rather than once per event fo…

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyServerManager.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyServerManager.java
@@ -64,6 +64,9 @@ public class GrizzlyServerManager implements HttpServerManager {
   // Defines the maximum size in bytes accepted for the http request header section (request line + headers)
   public static final String MAXIMUM_HEADER_SECTION_SIZE_PROPERTY_KEY = SYSTEM_PROPERTY_PREFIX + "http.headerSectionSize";
   private static final int MAX_KEEP_ALIVE_REQUESTS = -1;
+  // Only use a dedicated selector when more than 4 selectors are in use. A dedicated selector makes HTTP listener more responsive
+  // to new connections but can impact throughput if the acceptor:selector ratio is too high. This ensures the minimum ratio is
+  // 1:5.
   private static final int MIN_SELECTORS_FOR_DEDICATED_ACCEPTOR =
       getInteger(GrizzlyServerManager.class.getName() + ".MIN_SELECTORS_FOR_DEDICATED_ACCEPTOR", 4);
 

--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyServerManager.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyServerManager.java
@@ -64,9 +64,9 @@ public class GrizzlyServerManager implements HttpServerManager {
   // Defines the maximum size in bytes accepted for the http request header section (request line + headers)
   public static final String MAXIMUM_HEADER_SECTION_SIZE_PROPERTY_KEY = SYSTEM_PROPERTY_PREFIX + "http.headerSectionSize";
   private static final int MAX_KEEP_ALIVE_REQUESTS = -1;
-  // Only use a dedicated selector when more than 4 selectors are in use. A dedicated selector makes HTTP listener more responsive
-  // to new connections but can impact throughput if the acceptor:selector ratio is too high. This ensures the minimum ratio is
-  // 1:5.
+  // Only use a dedicated selector as an acceptor when there are more than 4 or more selectors. A dedicated acceptor makes HTTP
+  // listener more responsive to new connections but can impact throughput if the acceptor:selector ratio is too high. This
+  // ensures the minimum ratio is 1:3.
   private static final int MIN_SELECTORS_FOR_DEDICATED_ACCEPTOR =
       getInteger(GrizzlyServerManager.class.getName() + ".MIN_SELECTORS_FOR_DEDICATED_ACCEPTOR", 4);
 
@@ -110,7 +110,7 @@ public class GrizzlyServerManager implements HttpServerManager {
 
     transport
         .setNIOChannelDistributor(new RoundRobinConnectionDistributor(transport,
-                                                                      selectorCount > MIN_SELECTORS_FOR_DEDICATED_ACCEPTOR,
+                                                                      selectorCount >= MIN_SELECTORS_FOR_DEDICATED_ACCEPTOR,
                                                                       true));
 
     transport.setSelectorRunnersCount(selectorCount);

--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyServerManager.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyServerManager.java
@@ -65,7 +65,7 @@ public class GrizzlyServerManager implements HttpServerManager {
   public static final String MAXIMUM_HEADER_SECTION_SIZE_PROPERTY_KEY = SYSTEM_PROPERTY_PREFIX + "http.headerSectionSize";
   private static final int MAX_KEEP_ALIVE_REQUESTS = -1;
   private static final int MIN_SELECTORS_FOR_DEDICATED_ACCEPTOR =
-      getInteger(GrizzlyServerManager.class.getName() + ".MIN_SELECTORS_FOR_DEDICATED_ACCEPTOR", 8);
+      getInteger(GrizzlyServerManager.class.getName() + ".MIN_SELECTORS_FOR_DEDICATED_ACCEPTOR", 4);
 
   private static final long DISPOSE_TIMEOUT_MILLIS = 30000;
 


### PR DESCRIPTION
…r performance and back-pressure