### PR TITLE
MULE-14549: Use content-id for setting part name, when name is not pr…

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/HttpParser.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/HttpParser.java
@@ -7,8 +7,10 @@
 package org.mule.service.http.impl.service.server.grizzly;
 
 import static java.util.regex.Pattern.compile;
+import static org.mule.runtime.api.metadata.MediaType.MULTIPART_RELATED;
 import static org.mule.runtime.core.api.util.StringUtils.WHITE_SPACE;
 import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_DISPOSITION;
+import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_ID;
 
 import org.mule.runtime.http.api.domain.entity.multipart.HttpPart;
 
@@ -32,7 +34,6 @@ import javax.mail.util.ByteArrayDataSource;
 public class HttpParser {
 
   private static final Pattern SPACE_ENTITY_OR_PLUS_SIGN_REGEX = compile("%20|\\+");
-  private static final String CONTENT_DISPOSITION_PART_HEADER = CONTENT_DISPOSITION;
   private static final String NAME_ATTRIBUTE = "name";
 
   public static String extractPath(String uri) {
@@ -62,7 +63,7 @@ public class HttpParser {
 
         String filename = part.getFileName();
         String partName = filename;
-        String[] contentDispositions = part.getHeader(CONTENT_DISPOSITION_PART_HEADER);
+        String[] contentDispositions = part.getHeader(CONTENT_DISPOSITION);
         if (contentDispositions != null) {
           String contentDisposition = contentDispositions[0];
           if (contentDisposition.contains(NAME_ATTRIBUTE)) {
@@ -70,6 +71,14 @@ public class HttpParser {
             partName = partName.substring(0, partName.indexOf("\""));
           }
         }
+
+        if (partName == null && mimeMultipart.getContentType().contains(MULTIPART_RELATED.toString())) {
+          String[] contentIdHeader = part.getHeader(CONTENT_ID);
+          if (contentIdHeader != null && contentIdHeader.length > 0) {
+            partName = contentIdHeader[0];
+          }
+        }
+
         HttpPart httpPart =
             new HttpPart(partName, filename, IOUtils.toByteArray(part.getInputStream()), part.getContentType(), part.getSize());
 

--- a/src/test/java/org/mule/service/http/impl/service/server/grizzly/HttpParserTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/server/grizzly/HttpParserTestCase.java
@@ -6,14 +6,23 @@
  */
 package org.mule.service.http.impl.service.server.grizzly;
 
+import static java.lang.String.format;
+import static org.mule.runtime.api.metadata.MediaType.MULTIPART_RELATED;
 import static org.mule.service.http.impl.AllureConstants.HttpFeature.HTTP_SERVICE;
 import static org.mule.service.http.impl.AllureConstants.HttpFeature.HttpStory.PARSING;
 import static org.mule.service.http.impl.service.server.grizzly.HttpParser.normalizePathWithSpacesOrEncodedSpaces;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mule.service.http.impl.service.server.grizzly.HttpParser.parseMultipartContent;
 
+import org.mule.runtime.http.api.domain.entity.multipart.HttpPart;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
 
 import org.junit.Test;
 import io.qameta.allure.Feature;
@@ -24,6 +33,15 @@ import io.qameta.allure.Story;
 @Story(PARSING)
 public class HttpParserTestCase extends AbstractMuleTestCase {
 
+  private static final String CONTENT_ID = "someContentId";
+  private static final String MULTIPART_RELATED_WITH_CONTENT_ID =
+      format("--the-boundary\r\n"
+          + "Content-Type: text/plain\r\n"
+          + "Content-ID: %s\r\n"
+          + "\r\n"
+          + "content" + "\r\n"
+          + "--the-boundary\r\n", CONTENT_ID);
+
   @Test
   public void normalizePath() {
     String expectedNormalizedPath = " some path";
@@ -32,6 +50,15 @@ public class HttpParserTestCase extends AbstractMuleTestCase {
     assertThat(normalizePathWithSpacesOrEncodedSpaces("+some+path"), is(expectedNormalizedPath));
     assertThat(normalizePathWithSpacesOrEncodedSpaces("%20some+path"), is(expectedNormalizedPath));
     assertThat(normalizePathWithSpacesOrEncodedSpaces("+some%20path"), is(expectedNormalizedPath));
+  }
+
+  @Test
+  public void partWithoutNameButWithPresentContentIdHeader() throws IOException {
+    InputStream content = new ByteArrayInputStream(MULTIPART_RELATED_WITH_CONTENT_ID.getBytes());
+    Collection<HttpPart> httpPartCollection = parseMultipartContent(content, MULTIPART_RELATED.toString());
+    assertThat(httpPartCollection.size(), is(1));
+    HttpPart httpPart = httpPartCollection.iterator().next();
+    assertThat(httpPart.getName(), is(CONTENT_ID));
   }
 
 }


### PR DESCRIPTION
…esent.