### PR TITLE
Mule 14148: added configuration name to the loggers category to be able to filter them

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/HttpMessageLogger.java
+++ b/src/main/java/org/mule/service/http/impl/service/HttpMessageLogger.java
@@ -19,8 +19,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HttpMessageLogger extends HttpProbe.Adapter {
 
-  private static final Logger logger = LoggerFactory.getLogger(HttpMessageLogger.class);
-
+  private final Logger logger;
   private final LoggerType loggerType;
   private final ClassLoader classLoader;
 
@@ -28,9 +27,10 @@ public class HttpMessageLogger extends HttpProbe.Adapter {
     LISTENER, REQUESTER
   }
 
-  public HttpMessageLogger(final LoggerType loggerType, ClassLoader classLoader) {
+  public HttpMessageLogger(final LoggerType loggerType, String identifier, ClassLoader classLoader) {
     this.loggerType = loggerType;
     this.classLoader = classLoader;
+    this.logger = LoggerFactory.getLogger(HttpMessageLogger.class.getName() + "." + identifier);
   }
 
   @Override

--- a/src/main/java/org/mule/service/http/impl/service/client/GrizzlyHttpClient.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/GrizzlyHttpClient.java
@@ -223,7 +223,7 @@ public class GrizzlyHttpClient implements HttpClient {
     compositeTransportCustomizer
         .addTransportCustomizer(new IOStrategyTransportCustomizer(selectorScheduler, workerScheduler,
                                                                   DEFAULT_SELECTOR_THREAD_COUNT));
-    compositeTransportCustomizer.addTransportCustomizer(new LoggerTransportCustomizer());
+    compositeTransportCustomizer.addTransportCustomizer(new LoggerTransportCustomizer(name));
 
     if (clientSocketProperties != null) {
       compositeTransportCustomizer.addTransportCustomizer(new SocketConfigTransportCustomizer(clientSocketProperties));

--- a/src/main/java/org/mule/service/http/impl/service/client/LoggerTransportCustomizer.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/LoggerTransportCustomizer.java
@@ -27,11 +27,16 @@ import org.slf4j.LoggerFactory;
 public class LoggerTransportCustomizer implements TransportCustomizer {
 
   private static final Logger logger = LoggerFactory.getLogger(LoggerTransportCustomizer.class);
+  private final String identifier;
+
+  public LoggerTransportCustomizer(String identifier) {
+    this.identifier = identifier;
+  }
 
   @Override
   public void customize(TCPNIOTransport transport, FilterChainBuilder filterChainBuilder) {
     HttpCodecFilter httpCodecFilter = findHttpCodecFilter(filterChainBuilder);
-    httpCodecFilter.getMonitoringConfig().addProbes(new HttpMessageLogger(REQUESTER, currentThread().getContextClassLoader()));
+    httpCodecFilter.getMonitoringConfig().addProbes(new HttpMessageLogger(REQUESTER, identifier, currentThread().getContextClassLoader()));
   }
 
   private HttpCodecFilter findHttpCodecFilter(FilterChainBuilder filterChainBuilder) {

--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyServerManager.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyServerManager.java
@@ -210,7 +210,7 @@ public class GrizzlyServerManager implements HttpServerManager {
     sslFilterDelegate.addFilterForAddress(serverAddress, createSslFilter(tlsContextFactory));
     httpServerFilterDelegate
         .addFilterForAddress(serverAddress,
-                             createHttpServerFilter(connectionIdleTimeout, usePersistentConnections, delayedExecutor));
+                             createHttpServerFilter(connectionIdleTimeout, usePersistentConnections, delayedExecutor, identifier));
     final GrizzlyHttpServer grizzlyServer = new ManagedGrizzlyHttpServer(serverAddress, transport, httpListenerRegistry,
                                                                          schedulerSupplier,
                                                                          () -> executorProvider.removeExecutor(serverAddress),
@@ -234,7 +234,7 @@ public class GrizzlyServerManager implements HttpServerManager {
     addTimeoutFilter(serverAddress, usePersistentConnections, connectionIdleTimeout, delayedExecutor);
     httpServerFilterDelegate
         .addFilterForAddress(serverAddress,
-                             createHttpServerFilter(connectionIdleTimeout, usePersistentConnections, delayedExecutor));
+                             createHttpServerFilter(connectionIdleTimeout, usePersistentConnections, delayedExecutor, identifier));
     final GrizzlyHttpServer grizzlyServer = new ManagedGrizzlyHttpServer(serverAddress, transport, httpListenerRegistry,
                                                                          schedulerSupplier,
                                                                          () -> executorProvider.removeExecutor(serverAddress),
@@ -277,7 +277,7 @@ public class GrizzlyServerManager implements HttpServerManager {
   }
 
   private HttpServerFilter createHttpServerFilter(int connectionIdleTimeout, boolean usePersistentConnections,
-                                                  DelayedExecutor delayedExecutor) {
+                                                  DelayedExecutor delayedExecutor, ServerIdentifier identifier) {
     KeepAlive ka = null;
     if (usePersistentConnections) {
       ka = new KeepAlive();
@@ -286,7 +286,7 @@ public class GrizzlyServerManager implements HttpServerManager {
     }
     HttpServerFilter httpServerFilter =
         new HttpServerFilter(true, retrieveMaximumHeaderSectionSize(), ka, delayedExecutor);
-    httpServerFilter.getMonitoringConfig().addProbes(new HttpMessageLogger(LISTENER, currentThread().getContextClassLoader()));
+    httpServerFilter.getMonitoringConfig().addProbes(new HttpMessageLogger(LISTENER, identifier.getName(), currentThread().getContextClassLoader()));
     httpServerFilter.setAllowPayloadForUndefinedHttpMethods(true);
     return httpServerFilter;
   }

--- a/src/test/java/org/mule/service/http/impl/service/client/LoggerTransportCustomizerTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/client/LoggerTransportCustomizerTestCase.java
@@ -42,7 +42,7 @@ public class LoggerTransportCustomizerTestCase extends AbstractMuleTestCase {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
-  private LoggerTransportCustomizer loggerTransportCustomizer = new LoggerTransportCustomizer();
+  private LoggerTransportCustomizer loggerTransportCustomizer = new LoggerTransportCustomizer("config");
 
   @Test
   public void httpMessageLoggerIsAdded() {


### PR DESCRIPTION
Changed the logger category to append the name of the configuration in the end. That allows you to configure the wire logging just for one configuration without the need to enable it for the whole application.