### PR TITLE
MULE-15924: Miscellaneous performance improvements for proxy scenario

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/client/GrizzlyHttpClient.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/GrizzlyHttpClient.java
@@ -477,9 +477,9 @@ public class GrizzlyHttpClient implements HttpClient {
     }
 
     // If there's no transfer type specified, check the entity length to prioritize content length transfer
-    if (!hasTransferEncoding && !hasContentLength && request.getEntity().getLength().isPresent()) {
+    if (!hasTransferEncoding && !hasContentLength && request.getEntity().getBytesLength().isPresent()) {
       builder.addHeader(PRESERVE_HEADER_CASE ? CONTENT_LENGTH : HEADER_CONTENT_LENGTH,
-                        valueOf(request.getEntity().getLength().get()));
+                        valueOf(request.getEntity().getBytesLength().getAsLong()));
     }
 
     // If persistent connections are disabled, the "Connection: close" header must be explicitly added. AHC will

--- a/src/main/java/org/mule/service/http/impl/service/client/HttpResponseCreator.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/HttpResponseCreator.java
@@ -39,20 +39,29 @@ public class HttpResponseCreator {
     HttpResponseBuilder responseBuilder = HttpResponse.builder();
     responseBuilder.statusCode(response.getStatusCode());
     responseBuilder.reasonPhrase(response.getStatusText());
-    String contentType = response.getHeader(HEADER_CONTENT_TYPE);
-    String contentLength = response.getHeader(HEADER_CONTENT_LENGTH);
-    responseBuilder.entity(createEntity(inputStream, contentType, contentLength));
 
+    String contentType = null;
+    String contentLength = null;
     if (response.hasResponseHeaders()) {
       for (Entry<String, List<String>> headerEntry : response.getHeaders().entrySet()) {
-        responseBuilder.addHeaders(headerEntry.getKey(), headerEntry.getValue());
+        String headerName = headerEntry.getKey();
+        responseBuilder.addHeaders(headerName, headerEntry.getValue());
+
+        if (headerName.equalsIgnoreCase(HEADER_CONTENT_TYPE)) {
+          contentType = response.getHeader(HEADER_CONTENT_TYPE);
+        } else if (headerName.equalsIgnoreCase(HEADER_CONTENT_LENGTH)) {
+          contentLength = response.getHeader(HEADER_CONTENT_LENGTH);
+        }
       }
     }
+
+    responseBuilder.entity(createEntity(inputStream, contentType, contentLength));
+
     return responseBuilder.build();
   }
 
   private HttpEntity createEntity(InputStream stream, String contentType, String contentLength) {
-    Long contentLengthAsLong = -1L;
+    long contentLengthAsLong = -1L;
     if (contentLength != null) {
       contentLengthAsLong = parseLong(contentLength);
     }

--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/BaseResponseCompletionHandler.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/BaseResponseCompletionHandler.java
@@ -28,7 +28,7 @@ import org.glassfish.grizzly.http.HttpResponsePacket;
 import org.glassfish.grizzly.http.Protocol;
 import org.slf4j.Logger;
 
-import java.util.Optional;
+import java.util.OptionalLong;
 
 public abstract class BaseResponseCompletionHandler extends EmptyCompletionHandler<WriteResult> {
 
@@ -87,10 +87,10 @@ public abstract class BaseResponseCompletionHandler extends EmptyCompletionHandl
     }
 
     // If there's no transfer type specified, check the entity length to prioritize content length transfer (unless it's 1.0)
-    Optional<Long> length = httpResponse.getEntity().getLength();
+    OptionalLong length = httpResponse.getEntity().getBytesLength();
     Protocol protocol = sourceRequest.getProtocol();
     if (!hasTransferEncoding && !hasContentLength && length.isPresent() && !protocol.equals(HTTP_1_0)) {
-      responsePacketBuilder.header(CONTENT_LENGTH, valueOf(length.get()));
+      responsePacketBuilder.header(CONTENT_LENGTH, valueOf(length.getAsLong()));
     }
 
     HttpResponsePacket httpResponsePacket = responsePacketBuilder.build();

--- a/src/test/java/org/mule/service/http/impl/functional/HttpTransferLengthTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/functional/HttpTransferLengthTestCase.java
@@ -8,7 +8,8 @@ package org.mule.service.http.impl.functional;
 
 import static java.lang.Long.valueOf;
 import static java.util.Collections.singletonList;
-import static java.util.Optional.of;
+import static java.util.OptionalLong.empty;
+import static java.util.OptionalLong.of;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -16,7 +17,7 @@ import static org.junit.Assert.assertThat;
 import static org.mule.runtime.http.api.HttpConstants.HttpStatus.OK;
 import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_TYPE;
 import static org.mule.service.http.impl.AllureConstants.HttpFeature.HttpStory.TRANSFER_TYPE;
-import static org.mule.tck.junit4.matcher.IsEmptyOptional.empty;
+
 import org.mule.runtime.http.api.client.HttpClient;
 import org.mule.runtime.http.api.client.HttpClientConfiguration;
 import org.mule.runtime.http.api.domain.entity.ByteArrayHttpEntity;
@@ -31,13 +32,14 @@ import org.mule.runtime.http.api.domain.message.response.HttpResponseBuilder;
 import org.mule.service.http.impl.functional.client.AbstractHttpClientTestCase;
 import org.mule.service.http.impl.service.domain.entity.multipart.StreamedMultipartHttpEntity;
 
-import java.io.ByteArrayInputStream;
-import java.util.Optional;
-
-import io.qameta.allure.Story;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.OptionalLong;
+
+import io.qameta.allure.Story;
 
 @Story(TRANSFER_TYPE)
 public class HttpTransferLengthTestCase extends AbstractHttpClientTestCase {
@@ -75,7 +77,7 @@ public class HttpTransferLengthTestCase extends AbstractHttpClientTestCase {
     HttpEntity entity = request.getEntity();
     HttpResponseBuilder builder = HttpResponse.builder();
     try {
-      Optional<Long> expectedRequestLength = of(valueOf(REQUEST.length()));
+      OptionalLong expectedRequestLength = of(valueOf(REQUEST.length()));
       if (BYTE.equals(path)) {
         assertThat(entity, is(instanceOf(InputStreamHttpEntity.class)));
 
@@ -94,14 +96,14 @@ public class HttpTransferLengthTestCase extends AbstractHttpClientTestCase {
         builder.entity(new InputStreamHttpEntity(new ByteArrayInputStream("TEST".getBytes()), 4L));
       } else if (CHUNKED.equals(path)) {
         assertThat(entity, is(instanceOf(InputStreamHttpEntity.class)));
-        expectedRequestLength = Optional.empty();
+        expectedRequestLength = empty();
 
         builder.entity(new InputStreamHttpEntity(new ByteArrayInputStream("TEST".getBytes())));
       } else {
         expectedRequestLength = of(0L);
         assertThat(entity, is(instanceOf(EmptyHttpEntity.class)));
       }
-      assertThat(request.getEntity().getLength(), is(expectedRequestLength));
+      assertThat(request.getEntity().getBytesLength(), is(expectedRequestLength));
       return builder.build();
     } catch (AssertionError e) {
       return builder.statusCode(500).entity(new ByteArrayHttpEntity(e.getMessage().getBytes())).build();
@@ -115,7 +117,7 @@ public class HttpTransferLengthTestCase extends AbstractHttpClientTestCase {
         .entity(new ByteArrayHttpEntity(REQUEST.getBytes())).build();
     HttpResponse response = send(request);
 
-    assertThat(response.getEntity().getLength().get(), is(equalTo(4L)));
+    assertThat(response.getEntity().getBytesLength().getAsLong(), is(equalTo(4L)));
     assertThat(response.getEntity(), instanceOf(InputStreamHttpEntity.class));
   }
 
@@ -129,7 +131,7 @@ public class HttpTransferLengthTestCase extends AbstractHttpClientTestCase {
         .build();
     HttpResponse response = send(request);
 
-    assertThat(response.getEntity().getLength().get(), is(equalTo(102L)));
+    assertThat(response.getEntity().getBytesLength().getAsLong(), is(equalTo(102L)));
     assertThat(response.getEntity(), instanceOf(StreamedMultipartHttpEntity.class));
   }
 
@@ -138,7 +140,7 @@ public class HttpTransferLengthTestCase extends AbstractHttpClientTestCase {
     HttpRequest request = HttpRequest.builder().uri(getUri() + "/empty").build();
     HttpResponse response = send(request);
 
-    assertThat(response.getEntity().getLength().get(), is(equalTo(0L)));
+    assertThat(response.getEntity().getBytesLength().getAsLong(), is(equalTo(0L)));
     assertThat(response.getEntity(), instanceOf(EmptyHttpEntity.class));
   }
 
@@ -150,7 +152,7 @@ public class HttpTransferLengthTestCase extends AbstractHttpClientTestCase {
         .build();
     HttpResponse response = send(request);
 
-    assertThat(response.getEntity().getLength().get(), is(equalTo(4L)));
+    assertThat(response.getEntity().getBytesLength().getAsLong(), is(equalTo(4L)));
     assertThat(response.getEntity(), instanceOf(InputStreamHttpEntity.class));
   }
 
@@ -163,7 +165,7 @@ public class HttpTransferLengthTestCase extends AbstractHttpClientTestCase {
 
     HttpResponse response = send(request);
 
-    assertThat(response.getEntity().getLength(), is(empty()));
+    assertThat(response.getEntity().getBytesLength(), is(OptionalLong.empty()));
     assertThat(response.getEntity(), instanceOf(InputStreamHttpEntity.class));
   }
 

--- a/src/test/java/org/mule/service/http/impl/service/domain/entity/multipart/StreamedMultipartHttpEntityTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/domain/entity/multipart/StreamedMultipartHttpEntityTestCase.java
@@ -15,18 +15,20 @@ import static org.junit.Assert.assertThat;
 import static org.mule.runtime.api.metadata.MediaType.APPLICATION_JSON;
 import static org.mule.runtime.api.metadata.MediaType.TEXT;
 import static org.mule.service.http.impl.AllureConstants.HttpFeature.HTTP_SERVICE;
+
 import org.mule.runtime.core.api.util.IOUtils;
 import org.mule.runtime.http.api.domain.entity.HttpEntity;
 import org.mule.runtime.http.api.domain.entity.multipart.HttpPart;
 import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
-import org.junit.Before;
-import org.junit.Test;
 
 @Feature(HTTP_SERVICE)
 @Story("Entities")
@@ -108,11 +110,11 @@ public class StreamedMultipartHttpEntityTestCase extends AbstractMuleTestCase {
 
   @Test
   public void hasNoSizeUnlessSpecified() {
-    assertThat(entity.getLength().isPresent(), is(false));
+    assertThat(entity.getBytesLength().isPresent(), is(false));
     HttpEntity specifiedEntity = new StreamedMultipartHttpEntity(new ByteArrayInputStream(MULTIPART_CONTENT.getBytes()),
                                                                  "multipart/form-data; boundary=the-boundary",
                                                                  (long) MULTIPART_CONTENT.length());
-    assertThat(specifiedEntity.getLength().get(), is((long) MULTIPART_CONTENT.length()));
+    assertThat(specifiedEntity.getBytesLength().getAsLong(), is((long) MULTIPART_CONTENT.length()));
   }
 
 }


### PR DESCRIPTION
- Use `OptionalLong` instead of `Optional<Long>` for http entities length
- Minor improvement in special headers handling on requester response