### PR TITLE
MULE-18225: Fix http service unit tests

### DIFF
--- a/src/test/java/org/mule/service/http/impl/functional/client/HttpClientPostStreamingTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/functional/client/HttpClientPostStreamingTestCase.java
@@ -105,6 +105,9 @@ public abstract class HttpClientPostStreamingTestCase extends AbstractHttpClient
 
   protected void extractPayload(HttpRequest request) {
     try {
+      // InputStreamHttpEntity#getBytes didn't work until it was fixed by MULE-14729, using
+      // org.apache.commons.io.IOUtils#toByteArray instead.
+      // The bug was that IOUtils.readFully(this.inputStream, -1, true) throws an IOException because of "-1" parameter.
       payloadAfterDancing = new String(toByteArray(request.getEntity().getContent()));
     } catch (IOException e) {
       LOGGER.debug("Could not extract payload.");

--- a/src/test/java/org/mule/service/http/impl/functional/client/HttpClientPostStreamingTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/functional/client/HttpClientPostStreamingTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.service.http.impl.functional.client;
 
+import static org.apache.commons.io.IOUtils.toByteArray;
 import static org.mule.runtime.api.util.DataUnit.KB;
 import static org.mule.service.http.impl.AllureConstants.HttpFeature.HttpStory.STREAMING;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -104,7 +105,7 @@ public abstract class HttpClientPostStreamingTestCase extends AbstractHttpClient
 
   protected void extractPayload(HttpRequest request) {
     try {
-      payloadAfterDancing = new String(request.getEntity().getBytes());
+      payloadAfterDancing = new String(toByteArray(request.getEntity().getContent()));
     } catch (IOException e) {
       LOGGER.debug("Could not extract payload.");
     }

--- a/src/test/java/org/mule/service/http/impl/functional/client/HttpClientPropertyDecompressionTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/functional/client/HttpClientPropertyDecompressionTestCase.java
@@ -6,12 +6,14 @@
  */
 package org.mule.service.http.impl.functional.client;
 
+import static org.apache.commons.io.IOUtils.toByteArray;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.http.api.HttpHeaders.Names.ACCEPT_ENCODING;
 import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_ENCODING;
 import static org.mule.runtime.http.api.HttpHeaders.Values.GZIP;
 import static org.mule.service.http.impl.service.client.GrizzlyHttpClient.refreshSystemProperties;
+
 import org.mule.runtime.http.api.client.HttpClient;
 import org.mule.runtime.http.api.client.HttpClientConfiguration;
 import org.mule.runtime.http.api.domain.entity.ByteArrayHttpEntity;
@@ -85,7 +87,7 @@ public class HttpClientPropertyDecompressionTestCase extends AbstractHttpClientT
   private void validateResponse(HttpRequestBuilder builder, byte[] expectedResponse) throws IOException, TimeoutException {
     HttpResponse response = client.send(builder.uri(getUri()).build(), 30000, true, null);
 
-    assertThat(response.getEntity().getBytes(), is(expectedResponse));
+    assertThat(toByteArray(response.getEntity().getContent()), is(expectedResponse));
   }
 
   private ByteArrayOutputStream getCompressedData() throws IOException {

--- a/src/test/java/org/mule/service/http/impl/functional/client/HttpClientPropertyDecompressionTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/functional/client/HttpClientPropertyDecompressionTestCase.java
@@ -87,6 +87,9 @@ public class HttpClientPropertyDecompressionTestCase extends AbstractHttpClientT
   private void validateResponse(HttpRequestBuilder builder, byte[] expectedResponse) throws IOException, TimeoutException {
     HttpResponse response = client.send(builder.uri(getUri()).build(), 30000, true, null);
 
+    // InputStreamHttpEntity#getBytes didn't work until it was fixed by MULE-14729, using
+    // org.apache.commons.io.IOUtils#toByteArray instead.
+    // The bug was that IOUtils.readFully(this.inputStream, -1, true) throws an IOException because of "-1" parameter.
     assertThat(toByteArray(response.getEntity().getContent()), is(expectedResponse));
   }
 


### PR DESCRIPTION
The problem is in `InputStreamHttpEntity#getBytes`

```java
  @Override
  public byte[] getBytes() throws IOException {
    return IOUtils.readFully(this.inputStream, -1, true);
  }
```

It throws an `IOException`

```
java.io.IOException: length cannot be negative: -1
	at sun.misc.IOUtils.readFully(IOUtils.java:305)
	at org.mule.runtime.http.api.domain.entity.InputStreamHttpEntity.getBytes(InputStreamHttpEntity.java:60)
	at org.mule.service.http.impl.functional.client.HttpClientPostStreamingTestCase.extractPayload(HttpClientPostStreamingTestCase.java:108)
	at org.mule.service.http.impl.functional.client.NtlmHttpClientPostStreamingTestCase.doSetUpHttpResponse(NtlmHttpClientPostStreamingTestCase.java:51)
	at org.mule.service.http.impl.functional.client.HttpClientPostStreamingTestCase.setUpHttpResponse(HttpClientPostStreamingTestCase.java:99)
	at org.mule.service.http.impl.functional.client.AbstractHttpClientTestCase.lambda$setUp$0(AbstractHttpClientTestCase.java:42)
	at org.mule.service.http.impl.service.server.grizzly.GrizzlyRequestDispatcherFilter.handleRead(GrizzlyRequestDispatcherFilter.java:119)
```