### PR TITLE
As it is important for connection problems in multi-secured networks

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyHttpServer.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyHttpServer.java
@@ -102,9 +102,7 @@ public class GrizzlyHttpServer implements HttpServer, Supplier<ExecutorService> 
       }
     });
 
-    if (logger.isDebugEnabled()) {
-      logger.debug(format("Listening for connections on '%s'", listenerUrl()));
-    }
+    logger.info(format("Listening for connections on '%s'", listenerUrl()));
 
     openConnectionsCounter = 0;
 
@@ -149,9 +147,8 @@ public class GrizzlyHttpServer implements HttpServer, Supplier<ExecutorService> 
         }
       }
 
-      if (logger.isDebugEnabled()) {
-        logger.debug("Stopped listener on '{}'", listenerUrl());
-      }
+      logger.info("Stopped listener on '{}'", listenerUrl());
+
     } catch (InterruptedException e) {
       currentThread().interrupt();
     } finally {


### PR DESCRIPTION
to see on which port the listener is starting and whether it was stopped.

(e.g. ACL access-control-list configure VPCs virtual private networks)