### PR TITLE
MULE-19019: Avoid adding the Content-Length as a header when it's zero and the method semantic doesn't predict a body

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <asyncHttpClientVersion>1.14-MULE-019</asyncHttpClientVersion>
-        <grizzlyVersion>2.3.36-MULE-021-SNAPSHOT</grizzlyVersion>
+        <grizzlyVersion>2.3.36-MULE-021</grizzlyVersion>
         <javax.activation.version>1.2.0</javax.activation.version>
         <sun.mailapi.version>1.6.4</sun.mailapi.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <asyncHttpClientVersion>1.14-MULE-019</asyncHttpClientVersion>
-        <grizzlyVersion>2.3.36-MULE-020</grizzlyVersion>
+        <grizzlyVersion>2.3.36-MULE-021-SNAPSHOT</grizzlyVersion>
         <javax.activation.version>1.2.0</javax.activation.version>
         <sun.mailapi.version>1.6.4</sun.mailapi.version>
 

--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyHttpMessage.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyHttpMessage.java
@@ -53,7 +53,7 @@ public abstract class GrizzlyHttpMessage extends BaseHttpMessage implements Http
     isTransferEncodingChunked = requestPacket.isChunked();
     this.baseUri = getBaseProtocol() + "://" + localAddress.getHostString() + ":" + localAddress.getPort();
 
-    long contentLengthAsLong = -1L;
+    long contentLengthAsLong = isTransferEncodingChunked ? -1L : 0L;
     String contentLengthAsString = requestPacket.getHeader(CONTENT_LENGTH);
     if (contentLengthAsString != null) {
       contentLengthAsLong = parseLong(contentLengthAsString);

--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyServerManager.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyServerManager.java
@@ -6,6 +6,7 @@
  */
 package org.mule.service.http.impl.service.server.grizzly;
 
+import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.getInteger;
 import static java.lang.Integer.valueOf;
 import static java.lang.String.format;
@@ -71,6 +72,11 @@ public class GrizzlyServerManager implements HttpServerManager {
   // ensures the minimum ratio is 1:3.
   private static final int MIN_SELECTORS_FOR_DEDICATED_ACCEPTOR =
       getInteger(GrizzlyServerManager.class.getName() + ".MIN_SELECTORS_FOR_DEDICATED_ACCEPTOR", 4);
+
+  private static final String ALLOW_PAYLOAD_FOR_UNDEFINED_METHODS_PROPERTY =
+      SYSTEM_PROPERTY_PREFIX + "http.allowPayloadForUndefinedMethods";
+  static boolean ALLOW_PAYLOAD_FOR_UNDEFINED_METHODS =
+      parseBoolean(getProperty(ALLOW_PAYLOAD_FOR_UNDEFINED_METHODS_PROPERTY, "true"));
 
   private static final long DISPOSE_TIMEOUT_MILLIS = 30000;
 
@@ -327,7 +333,7 @@ public class GrizzlyServerManager implements HttpServerManager {
         new HttpServerFilter(true, retrieveMaximumHeaderSectionSize(), ka, delayedExecutor);
     httpServerFilter.getMonitoringConfig()
         .addProbes(new HttpMessageLogger(LISTENER, identifier.getName(), currentThread().getContextClassLoader()));
-    httpServerFilter.setAllowPayloadForUndefinedHttpMethods(true);
+    httpServerFilter.setAllowPayloadForUndefinedHttpMethods(ALLOW_PAYLOAD_FOR_UNDEFINED_METHODS);
     return httpServerFilter;
   }
 

--- a/src/test/java/org/mule/service/http/impl/functional/client/HttpClientOutboundPartsTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/functional/client/HttpClientOutboundPartsTestCase.java
@@ -17,6 +17,7 @@ import static org.mule.runtime.http.api.HttpConstants.Protocol.HTTPS;
 import static org.mule.service.http.impl.AllureConstants.HttpFeature.HttpStory.MULTIPART;
 import org.mule.runtime.api.lifecycle.CreateException;
 import org.mule.runtime.api.tls.TlsContextFactory;
+import org.mule.runtime.http.api.HttpConstants;
 import org.mule.runtime.http.api.client.HttpClient;
 import org.mule.runtime.http.api.client.HttpClientConfiguration;
 import org.mule.runtime.http.api.domain.entity.ByteArrayHttpEntity;
@@ -79,6 +80,7 @@ public class HttpClientOutboundPartsTestCase extends AbstractHttpClientTestCase 
     HttpPart part = new HttpPart("part1", new byte[size], TEXT_PLAIN, size);
 
     HttpResponse response = client.send(HttpRequest.builder()
+        .method(HttpConstants.Method.POST)
         .uri(getUri())
         .entity(new MultipartHttpEntity(singletonList(part)))
         .build(), getDefaultOptions(TIMEOUT));

--- a/src/test/java/org/mule/service/http/impl/functional/client/RedirectHttpClientPostStreamingTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/functional/client/RedirectHttpClientPostStreamingTestCase.java
@@ -7,7 +7,7 @@
 package org.mule.service.http.impl.functional.client;
 
 import static org.mule.runtime.http.api.HttpConstants.HttpStatus.OK;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.SEE_OTHER;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.TEMPORARY_REDIRECT;
 import static org.mule.runtime.http.api.HttpConstants.Method.POST;
 import static org.mule.service.http.impl.AllureConstants.HttpFeature.HttpStory.STREAMING;
 
@@ -33,7 +33,7 @@ public class RedirectHttpClientPostStreamingTestCase extends HttpClientPostStrea
   public HttpResponse setUpHttpResponse(HttpRequest request) {
     HttpResponseBuilder response = HttpResponse.builder();
     if (request.getUri().getPath().equals("/first")) {
-      return response.statusCode(SEE_OTHER.getStatusCode()).addHeader("Location", "/bla").build();
+      return response.statusCode(TEMPORARY_REDIRECT.getStatusCode()).addHeader("Location", "/bla").build();
     } else {
       extractPayload(request);
       return response.statusCode(OK.getStatusCode()).build();
@@ -44,7 +44,7 @@ public class RedirectHttpClientPostStreamingTestCase extends HttpClientPostStrea
   public HttpResponse doSetUpHttpResponse(HttpRequest request) {
     HttpResponseBuilder response = HttpResponse.builder();
     if (request.getUri().getPath().equals("/first")) {
-      return response.statusCode(SEE_OTHER.getStatusCode()).addHeader("Location", "/bla").build();
+      return response.statusCode(TEMPORARY_REDIRECT.getStatusCode()).addHeader("Location", "/bla").build();
     } else {
       extractPayload(request);
       return response.statusCode(OK.getStatusCode()).build();


### PR DESCRIPTION
(cherry picked from commit 4306448)