### PR TITLE
MULE-19099: HTTP Client async response handlers should preserve the c…

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/client/GrizzlyHttpClient.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/GrizzlyHttpClient.java
@@ -64,6 +64,7 @@ import org.mule.runtime.http.api.domain.entity.multipart.HttpPart;
 import org.mule.runtime.http.api.domain.message.request.HttpRequest;
 import org.mule.runtime.http.api.domain.message.response.HttpResponse;
 import org.mule.runtime.http.api.tcp.TcpClientSocketProperties;
+import org.mule.service.http.impl.service.client.async.PreservingClassLoaderAsyncHandler;
 import org.mule.service.http.impl.service.client.async.ResponseAsyncHandler;
 import org.mule.service.http.impl.service.client.async.ResponseBodyDeferringAsyncHandler;
 import org.slf4j.Logger;
@@ -382,9 +383,9 @@ public class GrizzlyHttpClient implements HttpClient {
     try {
       AsyncHandler<Response> asyncHandler;
       if (streamingEnabled) {
-        asyncHandler = new ResponseBodyDeferringAsyncHandler(future, responseBufferSize);
+        asyncHandler = new PreservingClassLoaderAsyncHandler<>(new ResponseBodyDeferringAsyncHandler(future, responseBufferSize));
       } else {
-        asyncHandler = new ResponseAsyncHandler(future);
+        asyncHandler = new PreservingClassLoaderAsyncHandler<>(new ResponseAsyncHandler(future));
       }
 
       asyncHttpClient.executeRequest(createGrizzlyRequest(request, options), asyncHandler);

--- a/src/main/java/org/mule/service/http/impl/service/client/async/PreservingClassLoaderAsyncHandler.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/async/PreservingClassLoaderAsyncHandler.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.service.http.impl.service.client.async;
+
+import static java.lang.Thread.currentThread;
+import static org.mule.runtime.api.util.Preconditions.checkState;
+
+import com.ning.http.client.AsyncHandler;
+import com.ning.http.client.HttpResponseBodyPart;
+import com.ning.http.client.HttpResponseHeaders;
+import com.ning.http.client.HttpResponseStatus;
+
+/**
+ * Wrapper class used to preserve the creation classloader on async handling methods.
+ *
+ * @param <T> See {@link com.ning.http.client.AsyncHandler}
+ */
+public class PreservingClassLoaderAsyncHandler<T> implements AsyncHandler<T> {
+
+  private AsyncHandler<T> delegate;
+  private final ClassLoader contextClassLoader;
+
+  public PreservingClassLoaderAsyncHandler(AsyncHandler<T> delegate) {
+    checkState(delegate != null, "Delegate cannot be null.");
+
+    this.delegate = delegate;
+    this.contextClassLoader = currentThread().getContextClassLoader();
+  }
+
+  @Override
+  public void onThrowable(Throwable throwable) {
+    ClassLoader oldClassLoader = currentThread().getContextClassLoader();
+    currentThread().setContextClassLoader(contextClassLoader);
+    try {
+      delegate.onThrowable(throwable);
+    } finally {
+      currentThread().setContextClassLoader(oldClassLoader);
+    }
+  }
+
+  @Override
+  public STATE onBodyPartReceived(HttpResponseBodyPart httpResponseBodyPart) throws Exception {
+    ClassLoader oldClassLoader = currentThread().getContextClassLoader();
+    currentThread().setContextClassLoader(contextClassLoader);
+    try {
+      return delegate.onBodyPartReceived(httpResponseBodyPart);
+    } finally {
+      currentThread().setContextClassLoader(oldClassLoader);
+    }
+  }
+
+  @Override
+  public STATE onStatusReceived(HttpResponseStatus httpResponseStatus) throws Exception {
+    ClassLoader oldClassLoader = currentThread().getContextClassLoader();
+    currentThread().setContextClassLoader(contextClassLoader);
+    try {
+      return delegate.onStatusReceived(httpResponseStatus);
+    } finally {
+      currentThread().setContextClassLoader(oldClassLoader);
+    }
+  }
+
+  @Override
+  public STATE onHeadersReceived(HttpResponseHeaders httpResponseHeaders) throws Exception {
+    ClassLoader oldClassLoader = currentThread().getContextClassLoader();
+    currentThread().setContextClassLoader(contextClassLoader);
+    try {
+      return delegate.onHeadersReceived(httpResponseHeaders);
+    } finally {
+      currentThread().setContextClassLoader(oldClassLoader);
+    }
+  }
+
+  @Override
+  public T onCompleted() throws Exception {
+    ClassLoader oldClassLoader = currentThread().getContextClassLoader();
+    currentThread().setContextClassLoader(contextClassLoader);
+    try {
+      return delegate.onCompleted();
+    } finally {
+      currentThread().setContextClassLoader(oldClassLoader);
+    }
+  }
+}

--- a/src/test/java/org/mule/service/http/impl/service/client/async/PreservingClassLoaderAsyncHandlerTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/client/async/PreservingClassLoaderAsyncHandlerTestCase.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.service.http.impl.service.client.async;
+
+import static java.lang.Thread.currentThread;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import org.mule.runtime.api.util.Reference;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import com.ning.http.client.AsyncHandler;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PreservingClassLoaderAsyncHandlerTestCase extends AbstractMuleTestCase {
+
+  @Mock
+  private AsyncHandler<Integer> delegate;
+
+  @Mock
+  private ClassLoader mockClassLoader;
+
+  private PreservingClassLoaderAsyncHandler<Integer> asyncHandler;
+  private ClassLoader classLoaderOnCreation;
+
+  @Before
+  public void setup() {
+    classLoaderOnCreation = currentThread().getContextClassLoader();
+    asyncHandler = new PreservingClassLoaderAsyncHandler<>(delegate);
+  }
+
+  @Test
+  public void creationClassLoaderIsPreservedOnCompleted() throws Exception {
+    Reference<ClassLoader> classLoaderOnCompleted = new Reference<>();
+    when(delegate.onCompleted()).then(invocation -> {
+      classLoaderOnCompleted.set(currentThread().getContextClassLoader());
+      return doCallRealMethod();
+    });
+
+    // Call the method with other classloader
+    withContextClassLoader(mockClassLoader, asyncHandler::onCompleted);
+    assertThat(classLoaderOnCompleted.get(), is(classLoaderOnCreation));
+  }
+
+  @Test
+  public void creationClassLoaderIsPreservedOnThrowable() {
+    Reference<ClassLoader> classLoaderOnThrowable = new Reference<>();
+    doAnswer(invocation -> {
+      classLoaderOnThrowable.set(currentThread().getContextClassLoader());
+      return doCallRealMethod();
+    }).when(delegate).onThrowable(any(Throwable.class));
+
+    // Call the method with other classloader
+    withContextClassLoader(mockClassLoader, () -> asyncHandler.onThrowable(new Throwable()));
+    assertThat(classLoaderOnThrowable.get(), is(classLoaderOnCreation));
+  }
+
+  @Test
+  public void creationClassLoaderIsPreservedOnBodyPartReceived() throws Exception {
+    Reference<ClassLoader> classLoaderOnBodyPartReceived = new Reference<>();
+    when(delegate.onBodyPartReceived(any())).then(invocation -> {
+      classLoaderOnBodyPartReceived.set(currentThread().getContextClassLoader());
+      return null;
+    });
+
+    // Call the method with other classloader
+    withContextClassLoader(mockClassLoader, () -> asyncHandler.onBodyPartReceived(null));
+    assertThat(classLoaderOnBodyPartReceived.get(), is(classLoaderOnCreation));
+  }
+
+  @Test
+  public void creationClassLoaderIsPreservedOnStatusReceived() throws Exception {
+    Reference<ClassLoader> classLoaderOnStatusReceived = new Reference<>();
+    when(delegate.onStatusReceived(any())).then(invocation -> {
+      classLoaderOnStatusReceived.set(currentThread().getContextClassLoader());
+      return null;
+    });
+
+    // Call the method with other classloader
+    withContextClassLoader(mockClassLoader, () -> asyncHandler.onStatusReceived(null));
+    assertThat(classLoaderOnStatusReceived.get(), is(classLoaderOnCreation));
+  }
+
+  @Test
+  public void creationClassLoaderIsPreservedOnHeadersReceived() throws Exception {
+    Reference<ClassLoader> classLoaderOnHeadersReceived = new Reference<>();
+    when(delegate.onHeadersReceived(any())).then(invocation -> {
+      classLoaderOnHeadersReceived.set(currentThread().getContextClassLoader());
+      return null;
+    });
+
+    // Call the method with other classloader
+    withContextClassLoader(mockClassLoader, () -> asyncHandler.onHeadersReceived(null));
+    assertThat(classLoaderOnHeadersReceived.get(), is(classLoaderOnCreation));
+  }
+}


### PR DESCRIPTION
…lass loader (#293)

(cherry picked from commit c02618771b304f97b0508c38513928b2d18097e9)