### PR TITLE
Buffer Size Calculation Fix

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandler.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandler.java
@@ -8,7 +8,7 @@ package org.mule.service.http.impl.service.client.async;
 
 import static com.ning.http.client.AsyncHandler.STATE.ABORT;
 import static com.ning.http.client.AsyncHandler.STATE.CONTINUE;
-import static java.lang.Integer.valueOf;
+import static java.lang.Long.valueOf;
 import static java.lang.Math.min;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -158,7 +158,7 @@ public class ResponseBodyDeferringAsyncHandler implements AsyncHandler<Response>
     int maxBufferSize = MAX_RECEIVE_BUFFER_SIZE;
     String contentLength = headers.getHeaders().getFirstValue(CONTENT_LENGTH);
     if (!isEmpty(contentLength) && isEmpty(headers.getHeaders().getFirstValue(TRANSFER_ENCODING))) {
-      int contentLengthInt = valueOf(contentLength);
+      long contentLengthLong = valueOf(contentLength);
       try {
         if (responseField != null && headers instanceof GrizzlyResponseHeaders) {
           maxBufferSize = (((HttpResponsePacket) responseField.get(headers)).getRequest().getConnection().getReadBufferSize());
@@ -166,7 +166,8 @@ public class ResponseBodyDeferringAsyncHandler implements AsyncHandler<Response>
       } catch (IllegalAccessException e) {
         LOGGER.debug("Unable to access connection buffer size.");
       }
-      bufferSize = min(maxBufferSize, contentLengthInt);
+      // XXX olamiral: can safely be casted to int since min will return maxBufferSize if contentLengthLong > maxBufferSize
+      bufferSize = (int) min(maxBufferSize, contentLengthLong);
     } else {
       // Assume maximum 32Kb chunk size + 10 bytes for chunk size and new lines etc. (need to confirm is this is needed, but use
       // for now)


### PR DESCRIPTION
Fixes buffer size calculation when http response content-length is greater than Integer max value

Could only reproduce when HTTP request stream response flag is set. Tested locally in Anypoint Studio embedded Mule Runtime.