### PR TITLE
MULE-19386: Fix failing HttpsGrizzlyServerManagerTestCase (#347)

### DIFF
--- a/src/test/java/org/mule/service/http/impl/service/server/grizzly/AbstractGrizzlyServerManagerTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/server/grizzly/AbstractGrizzlyServerManagerTestCase.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
 import static org.mule.runtime.http.api.HttpConstants.ALL_INTERFACES_ADDRESS;
 import static org.mule.runtime.http.api.HttpConstants.HttpStatus.OK;
+import static org.mule.service.http.impl.service.server.grizzly.GrizzlyHttpServer.setReplaceCtxClassloader;
 import static org.mule.tck.probe.PollingProber.DEFAULT_POLLING_INTERVAL;
 
 import org.mule.runtime.api.util.Reference;
@@ -318,6 +319,9 @@ public abstract class AbstractGrizzlyServerManagerTestCase extends AbstractMuleC
 
   @Test
   public void requestHandlerIsExecutedWithTheSameClassLoaderItWasAddedWith() throws Exception {
+    // This test is only valid when disableLogSeparation isn't configured.
+    setReplaceCtxClassloader(true);
+
     final GrizzlyServerManager serverManager =
         createServerManager(new HttpListenerRegistry(), new DefaultTcpServerSocketProperties());
 


### PR DESCRIPTION
(cherry picked from commit 576b668d18e4eba52999a6bee7679403f15c25b0)