### PR TITLE
MULE-19691: IOException should be thrown when having a timeout error …

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/ResponseStreamingCompletionHandler.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/ResponseStreamingCompletionHandler.java
@@ -158,6 +158,9 @@ public class ResponseStreamingCompletionHandler extends BaseResponseCompletionHa
     } catch (IOException ioException) {
       throw ioException;
     } catch (Exception e) {
+      if (e.getCause() instanceof IOException) {
+        throw (IOException) e.getCause();
+      }
       failed(e);
     }
   }

--- a/src/test/java/org/mule/service/http/impl/service/server/grizzly/ResponseStreamingCompletionHandlerTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/server/grizzly/ResponseStreamingCompletionHandlerTestCase.java
@@ -112,4 +112,19 @@ public class ResponseStreamingCompletionHandlerTestCase extends BaseResponseComp
 
     verify(getHandler(), times(1)).failed(any(Throwable.class));
   }
+
+  @Test
+  public void IOExceptionIsRethrownIfCauseOfFailure() throws IOException {
+    responseMock = HttpResponse.builder().entity(new InputStreamHttpEntity(mockStream)).build();
+    when(request.getProcessingState()).thenReturn(new ProcessingState());
+    handler = spy(new ResponseStreamingCompletionHandler(ctx,
+                                                         currentThread().getContextClassLoader(),
+                                                         request,
+                                                         responseMock,
+                                                         callback));
+
+    exception.expect(IOException.class);
+    when(mockStream.read(any(), anyInt(), anyInt())).thenThrow(new MuleRuntimeException(new IOException()));
+    handler.sendInputStreamChunk();
+  }
 }


### PR DESCRIPTION
…while starting to read a stream (no content) (#364) (#365)