### PR TITLE
MULE-19837: Fixing tests (#432)

### DIFF
--- a/src/test/java/org/mule/service/http/impl/service/client/GrizzlyHttpClientTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/client/GrizzlyHttpClientTestCase.java
@@ -24,6 +24,7 @@ import org.mule.runtime.api.scheduler.SchedulerConfig;
 import org.mule.runtime.api.scheduler.SchedulerService;
 import org.mule.runtime.http.api.client.HttpClient;
 import org.mule.runtime.http.api.client.HttpClientConfiguration;
+import org.mule.service.http.impl.service.server.grizzly.GrizzlyServerManager;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
 import java.lang.reflect.Field;
@@ -31,6 +32,7 @@ import java.lang.reflect.Field;
 import com.ning.http.client.AsyncHttpClient;
 import io.qameta.allure.Description;
 import io.qameta.allure.Issue;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -51,6 +53,11 @@ public class GrizzlyHttpClientTestCase extends AbstractMuleTestCase {
     when(schedulerConfig.withDirectRunCpuLightWhenTargetBusy(anyBoolean())).thenReturn(schedulerConfig2);
     when(schedulerConfig2.withMaxConcurrentTasks(anyInt())).thenReturn(mock(SchedulerConfig.class));
     when(schedulerConfig.withName(any())).thenReturn(mock(SchedulerConfig.class));
+  }
+
+  @After
+  public void tearDown() {
+    GrizzlyServerManager.refreshSystemProperties();
   }
 
   @Issue("MULE-19837")

--- a/src/test/java/org/mule/service/http/impl/service/server/HttpServiceMaxHeadersTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/server/HttpServiceMaxHeadersTestCase.java
@@ -30,6 +30,7 @@ import io.qameta.allure.Issue;
 import org.apache.http.NoHttpResponseException;
 import org.apache.http.StatusLine;
 import org.apache.http.client.fluent.Request;
+import org.junit.After;
 import org.junit.Test;
 
 public class HttpServiceMaxHeadersTestCase extends AbstractHttpServerTestCase {
@@ -52,6 +53,11 @@ public class HttpServiceMaxHeadersTestCase extends AbstractHttpServerTestCase {
           .addHeader(CONTENT_TYPE, TEXT.toRfcString())
           .build(), new IgnoreResponseStatusCallback());
     });
+  }
+
+  @After
+  public void tearDown() {
+    GrizzlyServerManager.refreshSystemProperties();
   }
 
   @Issue("MULE-19837")

--- a/src/test/java/org/mule/service/http/impl/service/server/grizzly/HttpGrizzlyServerManagerTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/server/grizzly/HttpGrizzlyServerManagerTestCase.java
@@ -44,6 +44,7 @@ import io.qameta.allure.Description;
 import io.qameta.allure.Issue;
 import org.glassfish.grizzly.nio.transport.TCPNIOTransport;
 import org.glassfish.grizzly.http.HttpServerFilter;
+import org.junit.After;
 import org.junit.Test;
 
 import io.qameta.allure.Feature;
@@ -54,6 +55,11 @@ import io.qameta.allure.Story;
 public class HttpGrizzlyServerManagerTestCase extends AbstractGrizzlyServerManagerTestCase {
 
   private final TlsContextFactory tlsContextFactory = TlsContextFactory.builder().buildDefault();
+
+  @After
+  public void tearDown() {
+    GrizzlyServerManager.refreshSystemProperties();
+  }
 
   @Override
   protected HttpServer getServer(ServerAddress address, ServerIdentifier id) throws ServerCreationException {


### PR DESCRIPTION
* MULE-19837: Grizzly Max Number of Headers

(cherry picked from commit 3f90ab3c92efdfaa487342eb0884ae2ad56f83dd)

* Fix

(cherry picked from commit 54d5b1ad2f9362e7bfc3c2fa83c83d3b2b5d63bc)

* Adding max client request headers

* Fixes

* Added teardown to tests

* Fix

* Formatting

(cherry picked from commit a9a5c44b93d32f5b6c72faf159a9fcc76a8bedce)