### PR TITLE
EE-8118: Optimizations for the HTTP proxy path

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyHttpMessage.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyHttpMessage.java
@@ -129,12 +129,12 @@ public abstract class GrizzlyHttpMessage extends BaseHttpMessage implements Http
 
   private void initializeHeaders() {
     this.headers = new CaseInsensitiveMultiMap(!PRESERVE_HEADER_CASE);
-    MimeHeaders headers = requestPacket.getHeaders();
+    MimeHeaders grizzlyHeaders = requestPacket.getHeaders();
     // For performance reasons we don't want to use Grizzly's MimeHeaders iterators because they are O(N^2)
     // The downside is that we are potentially decoding a header more than once if there are repetitions
-    for (int i = 0; i < headers.size(); i++) {
-      String header = headers.getName(i).toString();
-      String value = headers.getValue(i).toString();
+    for (int i = 0; i < grizzlyHeaders.size(); i++) {
+      String header = grizzlyHeaders.getName(i).toString();
+      String value = grizzlyHeaders.getValue(i).toString();
       this.headers.put(header, value);
     }
     this.headers = this.headers.toImmutableMultiMap();

--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyHttpMessage.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyHttpMessage.java
@@ -12,6 +12,8 @@ import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_LENGTH;
 import static org.mule.runtime.http.api.server.HttpServerProperties.PRESERVE_HEADER_CASE;
 import static org.mule.runtime.http.api.utils.HttpEncoderDecoderUtils.decodeQueryString;
 import static org.mule.runtime.http.api.utils.UriCache.getUriFromString;
+
+import org.glassfish.grizzly.http.util.MimeHeaders;
 import org.mule.runtime.api.util.MultiMap;
 import org.mule.runtime.http.api.domain.CaseInsensitiveMultiMap;
 import org.mule.runtime.http.api.domain.HttpProtocol;
@@ -127,11 +129,13 @@ public abstract class GrizzlyHttpMessage extends BaseHttpMessage implements Http
 
   private void initializeHeaders() {
     this.headers = new CaseInsensitiveMultiMap(!PRESERVE_HEADER_CASE);
-    for (String grizzlyHeaderName : requestPacket.getHeaders().names()) {
-      final Iterable<String> headerValues = requestPacket.getHeaders().values(grizzlyHeaderName);
-      for (String headerValue : headerValues) {
-        this.headers.put(grizzlyHeaderName, headerValue);
-      }
+    MimeHeaders headers = requestPacket.getHeaders();
+    // For performance reasons we don't want to use Grizzly's MimeHeaders iterators because they are O(N^2)
+    // The downside is that we are potentially decoding a header more than once if there are repetitions
+    for (int i = 0; i < headers.size(); i++) {
+      String header = headers.getName(i).toString();
+      String value = headers.getValue(i).toString();
+      this.headers.put(header, value);
     }
     this.headers = this.headers.toImmutableMultiMap();
   }


### PR DESCRIPTION
Each next on Grizzly's `MimeHeaders`' [names iterator](https://github.com/mulesoft/grizzly/blob/support/2.3.x/modules/http/src/main/java/org/glassfish/grizzly/http/util/MimeHeaders.java#L672) is O(N) because they want to skip repetitions. This makes the whole iteration O(N^2).

We prefer to do our own iteration since we actually want all values for a repeated header. The only downside is that in those cases we are doing the toString on the header name once for each repetition, but it is probably worth it in most cases. We don't expect to be dealing with a whole lot of repeated header names, but we really would like to scale properly with a good number of distinct headers names.