### PR TITLE
W-12528819: Fix NPE when adding a Cookie header with a wrong syntax

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/client/RequestHeaderPopulator.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/RequestHeaderPopulator.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.service.http.impl.service.client;
+
+import static org.mule.runtime.http.api.HttpHeaders.Names.CONNECTION;
+import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_LENGTH;
+import static org.mule.runtime.http.api.HttpHeaders.Names.COOKIE;
+import static org.mule.runtime.http.api.HttpHeaders.Names.TRANSFER_ENCODING;
+import static org.mule.runtime.http.api.HttpHeaders.Values.CLOSE;
+import static org.mule.runtime.http.api.server.HttpServerProperties.PRESERVE_HEADER_CASE;
+
+import static java.lang.String.valueOf;
+
+import static com.ning.http.client.cookie.CookieDecoder.decode;
+
+import org.mule.runtime.http.api.domain.message.request.HttpRequest;
+
+import java.util.Collection;
+
+import com.ning.http.client.RequestBuilder;
+import com.ning.http.client.cookie.Cookie;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RequestHeaderPopulator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RequestHeaderPopulator.class);
+
+  private final boolean usePersistentConnections;
+
+  public RequestHeaderPopulator(boolean usePersistentConnections) {
+    this.usePersistentConnections = usePersistentConnections;
+  }
+
+  private static final String HEADER_CONNECTION = CONNECTION.toLowerCase();
+  private static final String HEADER_CONTENT_LENGTH = CONTENT_LENGTH.toLowerCase();
+  private static final String HEADER_TRANSFER_ENCODING = TRANSFER_ENCODING.toLowerCase();
+  private static final String HEADER_COOKIE = COOKIE.toLowerCase();
+  private static final String COOKIE_SEPARATOR = ";";
+
+  public void populateHeaders(HttpRequest request, RequestBuilder builder) {
+    boolean hasTransferEncoding = false;
+    boolean hasContentLength = false;
+    boolean hasConnection = false;
+
+    for (String headerName : request.getHeaderNames()) {
+      // This is a workaround for https://github.com/javaee/grizzly/issues/1994
+      boolean specialHeader = false;
+
+      if (!hasTransferEncoding && headerName.equalsIgnoreCase(HEADER_TRANSFER_ENCODING)) {
+        hasTransferEncoding = true;
+        specialHeader = true;
+        builder.addHeader(PRESERVE_HEADER_CASE ? TRANSFER_ENCODING : HEADER_TRANSFER_ENCODING,
+                          request.getHeaderValue(headerName));
+      }
+      if (!hasContentLength && headerName.equalsIgnoreCase(HEADER_CONTENT_LENGTH)) {
+        hasContentLength = true;
+        specialHeader = true;
+        builder.addHeader(PRESERVE_HEADER_CASE ? CONTENT_LENGTH : HEADER_CONTENT_LENGTH, request.getHeaderValue(headerName));
+      }
+      if (!hasContentLength && headerName.equalsIgnoreCase(HEADER_CONNECTION)) {
+        hasConnection = true;
+        specialHeader = true;
+        builder.addHeader(PRESERVE_HEADER_CASE ? CONNECTION : HEADER_CONNECTION, request.getHeaderValue(headerName));
+      }
+      if (headerName.equalsIgnoreCase(HEADER_COOKIE)) {
+        specialHeader = true;
+        parseCookieHeaderAndAddCookies(builder, request.getHeaderValues(headerName));
+      }
+
+      if (!specialHeader) {
+        for (String headerValue : request.getHeaderValues(headerName)) {
+          builder.addHeader(headerName, headerValue);
+        }
+      }
+    }
+
+    // If there's no transfer type specified, check the entity length to prioritize content length transfer
+    if (!hasTransferEncoding && !hasContentLength && request.getEntity().getBytesLength().isPresent()) {
+      builder.addHeader(PRESERVE_HEADER_CASE ? CONTENT_LENGTH : HEADER_CONTENT_LENGTH,
+                        valueOf(request.getEntity().getBytesLength().getAsLong()));
+    }
+
+    // If persistent connections are disabled, the "Connection: close" header must be explicitly added. AHC will
+    // add "Connection: keep-alive" otherwise. (https://github.com/AsyncHttpClient/async-http-client/issues/885)
+
+    if (!usePersistentConnections) {
+      if (hasConnection && LOGGER.isDebugEnabled() && !CLOSE.equals(request.getHeaderValue(HEADER_CONNECTION))) {
+        LOGGER.debug("Persistent connections are disabled in the HTTP requester configuration, but the request already "
+            + "contains a Connection header with value {}. This header will be ignored, and a Connection: close header "
+            + "will be sent instead.", request.getHeaderValue(HEADER_CONNECTION));
+      }
+      builder.setHeader(PRESERVE_HEADER_CASE ? CONNECTION : HEADER_CONNECTION, CLOSE);
+    }
+  }
+
+  private void parseCookieHeaderAndAddCookies(RequestBuilder builder, Collection<String> headerValues) {
+    for (String cookieHeader : headerValues) {
+      for (String eachCookie : cookieHeader.split(COOKIE_SEPARATOR)) {
+        Cookie decodedCookiePair = decode(eachCookie.trim());
+        if (decodedCookiePair == null) {
+          LOGGER.debug("Couldn't decode '' as a cookie-pair. See RFC-6265, section 4.2.1 (Cookie header syntax)");
+        } else {
+          builder.addOrReplaceCookie(decodedCookiePair);
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/org/mule/service/http/impl/service/client/RequestHeaderPopulatorTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/client/RequestHeaderPopulatorTestCase.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.service.http.impl.service.client;
+
+import static org.mule.runtime.http.api.HttpHeaders.Names.COOKIE;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.junit.MockitoJUnit.rule;
+
+import org.mule.runtime.http.api.domain.entity.HttpEntity;
+import org.mule.runtime.http.api.domain.message.request.HttpRequest;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import com.ning.http.client.RequestBuilder;
+import com.ning.http.client.cookie.Cookie;
+import io.qameta.allure.Issue;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoRule;
+
+public class RequestHeaderPopulatorTestCase extends AbstractMuleTestCase {
+
+  @Rule
+  public MockitoRule mockitorule = rule();
+
+  @Mock
+  private HttpRequest muleRequest;
+
+  private RequestBuilder ahcRequestBuilder;
+
+  @Mock
+  private HttpEntity httpEntity;
+
+  private List<String> headerNames;
+
+  private RequestHeaderPopulator populator;
+
+  @Before
+  public void setUp() {
+    ahcRequestBuilder = new RequestBuilder();
+    headerNames = new ArrayList<>();
+
+    when(muleRequest.getEntity()).thenReturn(httpEntity);
+    when(muleRequest.getHeaderNames()).thenReturn(headerNames);
+
+    populator = new RequestHeaderPopulator(true);
+  }
+
+  @Test
+  public void singleCookiePair() {
+    // Given a cookie with only one cookie-pair
+    headerNames.add(COOKIE.toLowerCase());
+    when(muleRequest.getHeaderValues(COOKIE.toLowerCase())).thenReturn(singletonList("Name=Value"));
+
+    // When the populator handles the headers
+    populator.populateHeaders(muleRequest, ahcRequestBuilder);
+
+    // Then the resulting request builder has the corresponding cookie
+    Collection<String> cookiesInRequestAsString = getCookiesAsStrings(ahcRequestBuilder);
+    assertThat(cookiesInRequestAsString, contains("Name=Value"));
+  }
+
+  @Test
+  @Issue("W-12528819")
+  public void cookieWithSecureAndHttpOnly() {
+    // NOTE: This tests an invalid Cookie syntax given the RFC-6265: https://www.rfc-editor.org/rfc/rfc6265#section-4.2.1
+    // The secure and HttpOnly flags are only valid in the Set-Cookie header, and not in the Cookie header.
+    // Said that, Mule users usually implement their own cookie handling mechanism by passing the received Set-Cookie
+    // header as the Cookie header of the following request. Something like this:
+    //
+    // <some-connector:make-request />
+    // <http:request ...>
+    // <http:headers ><![CDATA[#[output application/java
+    // ---
+    // {
+    // "Cookie" : attributes.headers.'Set-Cookie'
+    // }]]]></http:headers>
+    // </http:request>
+    //
+    // Therefore, if the Set-Cookie has any of the mentioned flags, the added Cookie header of the next request would
+    // have an incorrect syntax, which we're testing here.
+
+    // Given a cookie with a cookie-pair, secure flag, and HttpOnly flag (notice the incorrect syntax).
+    headerNames.add(COOKIE.toLowerCase());
+    when(muleRequest.getHeaderValues(COOKIE.toLowerCase())).thenReturn(singletonList("Name=Value; secure; HttpOnly"));
+
+    // When the populator handles the headers
+    populator.populateHeaders(muleRequest, ahcRequestBuilder);
+
+    // Then the resulting request builder has the corresponding cookie
+    Collection<String> cookiesInRequestAsString = getCookiesAsStrings(ahcRequestBuilder);
+    assertThat(cookiesInRequestAsString, contains("Name=Value"));
+  }
+
+  private static Collection<String> getCookiesAsStrings(RequestBuilder requestBuilder) {
+    return requestBuilder.build().getCookies().stream().map(Cookie::toString).collect(toList());
+  }
+}


### PR DESCRIPTION
This PR extracts the method `populateHeaders()` from `GrizzlyHttpClient` to a new class `RequestHeaderPopulator`.
The only change apart of that refactor is a null-check in the method `parseCookieHeaderAndAddCookies()`, when the grizzly method `CookieDecoder.decode()` returned a null. It happens when the passed string doesn't honor the expected syntax.
One of the added test cases describes a situation where that syntax may be found. Please tell me if the comment in the case is not clear enough