### PR TITLE
W-14227000: Add system property to configure the time to wait for closing remaining connections on shutdown

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyHttpServer.java
+++ b/src/main/java/org/mule/service/http/impl/service/server/grizzly/GrizzlyHttpServer.java
@@ -6,6 +6,11 @@
  */
 package org.mule.service.http.impl.service.server.grizzly;
 
+import static org.mule.runtime.api.util.MuleSystemProperties.MULE_LOG_SEPARATION_DISABLED;
+import static org.mule.runtime.core.api.util.ClassUtils.setContextClassLoader;
+import static org.mule.runtime.http.api.server.MethodRequestMatcher.acceptAll;
+import static org.mule.service.http.impl.service.server.grizzly.MuleSslFilter.createSslFilter;
+
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.lang.System.getProperty;
@@ -14,10 +19,7 @@ import static java.lang.Thread.currentThread;
 import static java.util.Collections.synchronizedList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.mule.runtime.api.util.MuleSystemProperties.MULE_LOG_SEPARATION_DISABLED;
-import static org.mule.runtime.core.api.util.ClassUtils.setContextClassLoader;
-import static org.mule.runtime.http.api.server.MethodRequestMatcher.acceptAll;
-import static org.mule.service.http.impl.service.server.grizzly.MuleSslFilter.createSslFilter;
+
 import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.api.tls.TlsContextFactory;
 import org.mule.runtime.http.api.HttpConstants.Protocol;


### PR DESCRIPTION
About the system property:
- Name: `mule.http.graceful.shutdown.timeout`
- Unit: `milliseconds`
- Default value: Mule Graceful Shutdown Timeout (this way we preserve backwards compatibility)
- Special values:
  * `"0"` means `no graceful shutdown`.
  * `"-1"` means `until there are zero established connections`
