### PR TITLE
W-16640190: Avoid deadlock when consuming the payload in the whenComplete callback of sendAsync result

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/client/GrizzlyHttpClient.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/GrizzlyHttpClient.java
@@ -448,7 +448,8 @@ public class GrizzlyHttpClient implements HttpClient {
       CompletableFuture<HttpResponse> auxFuture = new CompletableFuture<>();
       if (streamingEnabled) {
         asyncHandler =
-            new PreservingClassLoaderAsyncHandler<>(new ResponseBodyDeferringAsyncHandler(auxFuture, responseBufferSize));
+            new PreservingClassLoaderAsyncHandler<>(new ResponseBodyDeferringAsyncHandler(auxFuture, responseBufferSize,
+                                                                                          workerScheduler));
       } else {
         asyncHandler = new PreservingClassLoaderAsyncHandler<>(new ResponseAsyncHandler(auxFuture));
       }

--- a/src/main/java/org/mule/service/http/impl/service/util/ThreadContext.java
+++ b/src/main/java/org/mule/service/http/impl/service/util/ThreadContext.java
@@ -17,13 +17,17 @@ import org.slf4j.MDC;
  * Auxiliary auto-closeable class to be used in a try-with-resources scope. Client would create an instance of ThreadContext
  * passing a class loader and a map to be set as mdc while the instance is open. When the instance goes out of scope, it's closed
  * and the previous class loader and mdc are restored.
- *
- * Usage example: <code>
+ * <p>
+ * Usage example:
+ * 
+ * <pre>
+ * {@code
  *   try (ThreadContext tc = new ThreadContext(theClassLoader, theMDC)) {
  *     // The code in this scope will use theClassLoader and theMDC.
  *   }
  *   // Out of the scope, the code will use the outer class loader and mdc.
- * </code>
+ * }
+ * </pre>
  *
  * It's only intended to be used in a try-with-resources block, avoid using it in another fashion.
  */

--- a/src/test/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandlerTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandlerTestCase.java
@@ -6,17 +6,28 @@
  */
 package org.mule.service.http.impl.service.client.async;
 
+import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_LENGTH;
+import static org.mule.runtime.http.api.HttpHeaders.Names.TRANSFER_ENCODING;
+import static org.mule.service.http.impl.AllureConstants.HttpFeature.HTTP_SERVICE;
+import static org.mule.service.http.impl.AllureConstants.HttpFeature.HttpStory.STREAMING;
+import static org.mule.service.http.impl.service.client.async.ResponseBodyDeferringAsyncHandler.refreshSystemProperties;
+
+import static java.lang.System.clearProperty;
+import static java.lang.System.setProperty;
+import static java.nio.ByteBuffer.allocateDirect;
+import static java.nio.ByteBuffer.wrap;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+
 import static com.ning.http.client.AsyncHandler.STATE.ABORT;
 import static com.ning.http.client.AsyncHandler.STATE.CONTINUE;
-import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -26,35 +37,36 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_LENGTH;
-import static org.mule.runtime.http.api.HttpHeaders.Names.TRANSFER_ENCODING;
-import static org.mule.service.http.impl.AllureConstants.HttpFeature.HTTP_SERVICE;
-import static org.mule.service.http.impl.AllureConstants.HttpFeature.HttpStory.STREAMING;
+
 import org.mule.runtime.api.util.Reference;
 import org.mule.runtime.api.util.concurrent.Latch;
+import org.mule.runtime.core.api.util.IOUtils;
 import org.mule.runtime.http.api.domain.message.response.HttpResponse;
 import org.mule.service.http.impl.util.TimedPipedInputStream;
 import org.mule.service.http.impl.util.TimedPipedOutputStream;
 import org.mule.tck.junit4.AbstractMuleTestCase;
-import org.mule.tck.probe.JUnitProbe;
+import org.mule.tck.probe.JUnitLambdaProbe;
 import org.mule.tck.probe.PollingProber;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeoutException;
 
 import com.ning.http.client.AsyncHandler;
 import com.ning.http.client.FluentCaseInsensitiveStringsMap;
 import com.ning.http.client.HttpResponseHeaders;
 import com.ning.http.client.HttpResponseStatus;
 import com.ning.http.client.providers.grizzly.GrizzlyResponseBodyPart;
-
-import java.io.InputStream;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeoutException;
-
 import io.qameta.allure.Feature;
 import io.qameta.allure.Issue;
 import io.qameta.allure.Story;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.http.HttpContent;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 @Feature(HTTP_SERVICE)
@@ -65,84 +77,80 @@ public class ResponseBodyDeferringAsyncHandlerTestCase extends AbstractMuleTestC
   private static final int POLL_DELAY = 300;
   private static final int BUFFER_SIZE = 1024;
 
-  private final ExecutorService executor = newSingleThreadExecutor();
+  private final ExecutorService testExecutor = newSingleThreadExecutor();
   private final PollingProber prober = new PollingProber(PROBE_TIMEOUT, POLL_DELAY);
+
+  private final ExecutorService workersExecutor = newFixedThreadPool(5);
+
+  private static final String READ_TIMEOUT_PROPERTY_NAME = "mule.http.responseStreaming.pipeReadTimeoutMillis";
+
+  @Before
+  public void setup() {
+    setProperty(READ_TIMEOUT_PROPERTY_NAME, "100");
+    refreshSystemProperties();
+  }
+
+  @After
+  public void tearDown() {
+    clearProperty(READ_TIMEOUT_PROPERTY_NAME);
+    refreshSystemProperties();
+  }
 
   @Test
   public void doesNotStreamWhenPossible() throws Exception {
     CompletableFuture<HttpResponse> future = new CompletableFuture<>();
     Reference<InputStream> responseContent = new Reference<>();
-    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE);
+    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE, workersExecutor);
     handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS));
-    GrizzlyResponseBodyPart bodyPart = mock(GrizzlyResponseBodyPart.class, RETURNS_DEEP_STUBS);
-    when(bodyPart.isLast()).thenReturn(true);
+    GrizzlyResponseBodyPart bodyPart = mockBodyPart(true, new byte[0]);
     future.whenComplete((response, exception) -> responseContent.set(response.getEntity().getContent()));
 
     assertThat(handler.onBodyPartReceived(bodyPart), is(CONTINUE));
 
-    prober.check(new JUnitProbe() {
-
-      @Override
-      protected boolean test() throws Exception {
-        assertThat(responseContent.get(), not(nullValue()));
-        assertThat(responseContent.get(), not(instanceOf(TimedPipedInputStream.class)));
-        return true;
-      }
-    });
+    prober.check(new JUnitLambdaProbe(() -> {
+      assertThat(responseContent.get(), not(instanceOf(TimedPipedInputStream.class)));
+      return true;
+    }));
   }
 
   @Test
   public void streamsWhenRequired() throws Exception {
     CompletableFuture<HttpResponse> future = new CompletableFuture<>();
     Reference<InputStream> responseContent = new Reference<>();
-    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE);
+    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE, workersExecutor);
     handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS));
-    GrizzlyResponseBodyPart bodyPart = mock(GrizzlyResponseBodyPart.class, RETURNS_DEEP_STUBS);
-    when(bodyPart.isLast()).thenReturn(false);
+    GrizzlyResponseBodyPart bodyPart = mockBodyPart(false, new byte[0]);
     future.whenComplete((response, exception) -> responseContent.set(response.getEntity().getContent()));
 
     assertThat(handler.onBodyPartReceived(bodyPart), is(CONTINUE));
 
-    prober.check(new JUnitProbe() {
-
-      @Override
-      protected boolean test() throws Exception {
-        assertThat(responseContent.get(), not(nullValue()));
-        assertThat(responseContent.get(), instanceOf(TimedPipedInputStream.class));
-        return true;
-      }
-    });
+    prober.check(new JUnitLambdaProbe(() -> {
+      assertThat(responseContent.get(), instanceOf(TimedPipedInputStream.class));
+      return true;
+    }));
   }
 
   @Test
   @Issue("MULE-19208")
   public void handlerAbortsResponseWhenAnErrorOccurred() throws Exception {
     CompletableFuture<HttpResponse> future = new CompletableFuture<>();
-    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE);
-    GrizzlyResponseBodyPart bodyPart = mock(GrizzlyResponseBodyPart.class, RETURNS_DEEP_STUBS);
-    when(bodyPart.isLast()).thenReturn(false);
+    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE, workersExecutor);
+    GrizzlyResponseBodyPart bodyPart = mockBodyPart(false, new byte[0]);
 
     handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS));
     handler.onThrowable(new TimeoutException("Timeout exceeded"));
     AsyncHandler.STATE state = handler.onBodyPartReceived(bodyPart);
     assertThat(state, is(ABORT));
 
-    prober.check(new JUnitProbe() {
-
-      @Override
-      protected boolean test() throws Exception {
-        return future.isCompletedExceptionally();
-      }
-    });
+    prober.check(new JUnitLambdaProbe(future::isCompletedExceptionally));
   }
 
   @Test
   @Issue("MULE-19208")
   public void handlerDoesNotTryToWriteAPartIfAnErrorOccurred() throws Exception {
     CompletableFuture<HttpResponse> future = new CompletableFuture<>();
-    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE);
-    GrizzlyResponseBodyPart bodyPart = mock(GrizzlyResponseBodyPart.class, RETURNS_DEEP_STUBS);
-    when(bodyPart.isLast()).thenReturn(false);
+    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE, workersExecutor);
+    GrizzlyResponseBodyPart bodyPart = mockBodyPart(false, new byte[0]);
 
     handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS));
     handler.onThrowable(new TimeoutException("Timeout exceeded"));
@@ -155,37 +163,29 @@ public class ResponseBodyDeferringAsyncHandlerTestCase extends AbstractMuleTestC
   @Issue("MULE-19208")
   public void handlerClosesPipedStreamIfAnErrorOccurredBetweenTwoParts() throws Exception {
     CompletableFuture<HttpResponse> future = new CompletableFuture<>();
-    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE);
+    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE, workersExecutor);
     GrizzlyResponseBodyPart bodyPartBeforeError = mock(GrizzlyResponseBodyPart.class, RETURNS_DEEP_STUBS);
     GrizzlyResponseBodyPart bodyPartAfterError = mock(GrizzlyResponseBodyPart.class, RETURNS_DEEP_STUBS);
-    when(bodyPartBeforeError.isLast()).thenReturn(false);
-    when(bodyPartAfterError.isLast()).thenReturn(false);
 
     handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS));
     assertThat(handler.onBodyPartReceived(bodyPartBeforeError), is(CONTINUE));
     handler.onThrowable(new TimeoutException("Timeout exceeded"));
     assertThat(handler.onBodyPartReceived(bodyPartAfterError), is(ABORT));
 
-    prober.check(new JUnitProbe() {
-
-      @Override
-      protected boolean test() throws Exception {
-        // When the TimedPipedInputStream is closed by writer, read returns -1 indicating EOF.
-        byte[] result = new byte[16];
-        return future.get().getEntity().getContent().read(result) == -1;
-      }
-    });
+    prober.check(new JUnitLambdaProbe(() -> {
+      // When the TimedPipedInputStream is closed by writer, read returns -1 indicating EOF.
+      byte[] result = new byte[16];
+      return future.get().getEntity().getContent().read(result) == -1;
+    }));
   }
 
   @Test
   @Issue("MULE-19208")
   public void handlerDoesNotTryToWriteAPartIfAnErrorOccurredBetweenTwoParts() throws Exception {
     CompletableFuture<HttpResponse> future = new CompletableFuture<>();
-    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE);
-    GrizzlyResponseBodyPart bodyPartBeforeError = mock(GrizzlyResponseBodyPart.class, RETURNS_DEEP_STUBS);
-    GrizzlyResponseBodyPart bodyPartAfterError = mock(GrizzlyResponseBodyPart.class, RETURNS_DEEP_STUBS);
-    when(bodyPartBeforeError.isLast()).thenReturn(false);
-    when(bodyPartAfterError.isLast()).thenReturn(false);
+    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE, workersExecutor);
+    GrizzlyResponseBodyPart bodyPartBeforeError = mockBodyPart(false, new byte[0]);
+    GrizzlyResponseBodyPart bodyPartAfterError = mockBodyPart(false, new byte[0]);
 
     handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS));
     assertThat(handler.onBodyPartReceived(bodyPartBeforeError), is(CONTINUE));
@@ -200,10 +200,11 @@ public class ResponseBodyDeferringAsyncHandlerTestCase extends AbstractMuleTestC
   @Issue("MULE-19208")
   public void readerDoesNotBlockWhenNobodyWroteInTheStreamYet() throws Exception {
     CompletableFuture<HttpResponse> future = new CompletableFuture<>();
-    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE);
+    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE, workersExecutor);
     GrizzlyResponseBodyPart bodyPart = mock(GrizzlyResponseBodyPart.class, RETURNS_DEEP_STUBS);
     when(bodyPart.isLast()).thenReturn(false);
     when(bodyPart.getBodyPartBytes()).thenReturn("payload".getBytes());
+    when(bodyPart.getBodyByteBuffer()).thenReturn(allocateDirect(0));
     handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS));
     Latch writeLatch = new Latch();
     doAnswer(invocation -> {
@@ -211,7 +212,7 @@ public class ResponseBodyDeferringAsyncHandlerTestCase extends AbstractMuleTestC
       return invocation.callRealMethod();
     }).when(bodyPart).writeTo(any(TimedPipedOutputStream.class));
 
-    executor.submit(() -> {
+    testExecutor.submit(() -> {
       try {
         assertThat(handler.onBodyPartReceived(bodyPart), is(CONTINUE));
       } catch (Exception e) {
@@ -220,15 +221,12 @@ public class ResponseBodyDeferringAsyncHandlerTestCase extends AbstractMuleTestC
     });
 
     // The read operation isn't blocking when nobody wrote in the stream.
-    prober.check(new JUnitProbe() {
-
-      @Override
-      protected boolean test() throws Exception {
-        // When the TimedPipedInputStream was never written and it's still open, read returns 0.
-        byte[] result = new byte[16];
-        return future.get().getEntity().getContent().read(result) == 0;
-      }
-    });
+    prober.check(new JUnitLambdaProbe(() -> {
+      // When the TimedPipedInputStream was never written and it's still open, read returns 0.
+      byte[] result = new byte[16];
+      int bytesRead = future.get().getEntity().getContent().read(result);
+      return bytesRead == 0;
+    }));
 
     writeLatch.release();
 
@@ -236,21 +234,17 @@ public class ResponseBodyDeferringAsyncHandlerTestCase extends AbstractMuleTestC
     handler.onCompleted();
 
     // The read operation returns EOF when the pipe was closed while it was empty.
-    prober.check(new JUnitProbe() {
-
-      @Override
-      protected boolean test() throws Exception {
-        // When the TimedPipedInputStream is closed by writer, read returns -1 indicating EOF.
-        byte[] result = new byte[16];
-        return future.get().getEntity().getContent().read(result) == -1;
-      }
-    });
+    prober.check(new JUnitLambdaProbe(() -> {
+      // When the TimedPipedInputStream is closed by writer, read returns -1 indicating EOF.
+      byte[] result = new byte[16];
+      return future.get().getEntity().getContent().read(result) == -1;
+    }));
   }
 
   @Test
   public void abortsWhenPipeIsClosed() throws Exception {
     CompletableFuture<HttpResponse> future = new CompletableFuture<>();
-    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE);
+    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE, workersExecutor);
     handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS));
     GrizzlyResponseBodyPart bodyPart = spy(new GrizzlyResponseBodyPart(mock(HttpContent.class), mock(Connection.class)));
     when(bodyPart.isLast()).thenReturn(false);
@@ -263,16 +257,54 @@ public class ResponseBodyDeferringAsyncHandlerTestCase extends AbstractMuleTestC
   @Test
   public void doesNotThrowExceptionIfContentLengthIsGreaterThanMaxInteger() throws Exception {
     CompletableFuture<HttpResponse> future = new CompletableFuture<>();
-    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, -1);
+    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, -1, workersExecutor);
     handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS));
 
     FluentCaseInsensitiveStringsMap headersMap = mock((FluentCaseInsensitiveStringsMap.class));
-    when(headersMap.getFirstValue(eq(CONTENT_LENGTH))).thenReturn(Long.toString((long) Integer.MAX_VALUE * 2));
-    when(headersMap.getFirstValue(eq(TRANSFER_ENCODING))).thenReturn("");
+    when(headersMap.getFirstValue(CONTENT_LENGTH)).thenReturn(Long.toString((long) Integer.MAX_VALUE * 2));
+    when(headersMap.getFirstValue(TRANSFER_ENCODING)).thenReturn("");
 
     HttpResponseHeaders headers = mock(HttpResponseHeaders.class);
     when(headers.getHeaders()).thenReturn(headersMap);
 
     assertThat(handler.onHeadersReceived(headers), is(CONTINUE));
+  }
+
+  @Test
+  @Issue("W-16640190")
+  public void readFromPipeInWhenCompleteDoesNotCauseADeadlock() throws Exception {
+    CompletableFuture<HttpResponse> future = new CompletableFuture<>();
+    Reference<String> responseContent = new Reference<>();
+    ResponseBodyDeferringAsyncHandler handler = new ResponseBodyDeferringAsyncHandler(future, BUFFER_SIZE, workersExecutor);
+    handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS));
+
+    GrizzlyResponseBodyPart intermediatePart = mockBodyPart(false, "Hello ".getBytes());
+    GrizzlyResponseBodyPart lastPart = mockBodyPart(true, "world".getBytes());
+
+    future.whenComplete((response, exception) -> {
+      String responseAsString = IOUtils.toString(response.getEntity().getContent());
+      responseContent.set(responseAsString);
+    });
+
+    assertThat(handler.onBodyPartReceived(intermediatePart), is(CONTINUE));
+    assertThat(handler.onBodyPartReceived(lastPart), is(CONTINUE));
+    assertThat(handler.onCompleted(), is(nullValue()));
+
+    prober.check(new JUnitLambdaProbe(() -> {
+      assertThat(responseContent.get(), is("Hello world"));
+      return true;
+    }));
+  }
+
+  private static GrizzlyResponseBodyPart mockBodyPart(boolean isLast, byte[] content) throws IOException {
+    GrizzlyResponseBodyPart bodyPart = mock(GrizzlyResponseBodyPart.class, RETURNS_DEEP_STUBS);
+    when(bodyPart.isLast()).thenReturn(isLast);
+    when(bodyPart.getBodyByteBuffer()).thenReturn(wrap(content));
+    doAnswer(invocation -> {
+      OutputStream outputStream = invocation.getArgument(0);
+      outputStream.write(content);
+      return content.length;
+    }).when(bodyPart).writeTo(any(OutputStream.class));
+    return bodyPart;
   }
 }


### PR DESCRIPTION
(cherry picked from commit https://github.com/mulesoft/mule-http-service/commit/2cc6309ef4dc9a00d499c68c494eef940f0a85e2)