### PR TITLE
W-17617940: Fix race condition between the reception of the last body part and the response completion when streaming the response in the client

### DIFF
--- a/src/main/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandler.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandler.java
@@ -343,6 +343,8 @@ public class ResponseBodyDeferringAsyncHandler implements AsyncHandler<Response>
       // there may have been no a body, handle partial response
       handleIfNecessary();
       if (!lastPartReceived.get()) {
+        // If the last part was not received yet, it won't be received. It's because AHC doesn't call the onBodyPartReceived for
+        // the last part if it's empty. In that case, we need to close the pipe here.
         closeOut();
       }
       return null;

--- a/src/main/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandler.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandler.java
@@ -45,7 +45,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
-import com.damnhandy.uri.template.UriTemplate;
 import com.ning.http.client.AsyncHandler;
 import com.ning.http.client.HttpResponseBodyPart;
 import com.ning.http.client.HttpResponseHeaders;

--- a/src/main/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandler.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandler.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
+import com.damnhandy.uri.template.UriTemplate;
 import com.ning.http.client.AsyncHandler;
 import com.ning.http.client.HttpResponseBodyPart;
 import com.ning.http.client.HttpResponseHeaders;
@@ -99,6 +100,7 @@ public class ResponseBodyDeferringAsyncHandler implements AsyncHandler<Response>
   }
 
   private final AtomicReference<Throwable> throwableReceived = new AtomicReference<>();
+  private final AtomicBoolean lastPartReceived = new AtomicBoolean(false);
 
   public ResponseBodyDeferringAsyncHandler(CompletableFuture<HttpResponse> future, int userDefinedBufferSize,
                                            ExecutorService workerScheduler,
@@ -238,6 +240,9 @@ public class ResponseBodyDeferringAsyncHandler implements AsyncHandler<Response>
     // body arrived, can handle the partial response
     try {
       MDC.setContextMap(mdc);
+      if (bodyPart.isLast()) {
+        lastPartReceived.set(true);
+      }
       if (errorDetected()) {
         return closeAndAbort();
       }
@@ -281,19 +286,25 @@ public class ResponseBodyDeferringAsyncHandler implements AsyncHandler<Response>
       pauseHandler.requestPause();
       nonBlockingStreamWriter
           .addDataToWrite(output, bodyPart.getBodyPartBytes(), this::availableSpaceInPipe)
-          .whenComplete(resumeCallback(pauseHandler));
+          .whenComplete(resumeCallback(pauseHandler, bodyPart.isLast()));
     } else {
       bodyPart.writeTo(output);
+      if (bodyPart.isLast()) {
+        closeOut();
+      }
     }
     return CONTINUE;
   }
 
-  private BiConsumer<Void, Throwable> resumeCallback(final PauseHandler pauseHandler) {
+  private BiConsumer<Void, Throwable> resumeCallback(final PauseHandler pauseHandler, boolean isLastPart) {
     return (ignored, error) -> {
       if (error != null) {
         onThrowable(error);
       }
       try {
+        if (isLastPart) {
+          closeOut();
+        }
         pauseHandler.resume();
       } catch (Exception e) {
         onThrowable(e);
@@ -329,9 +340,12 @@ public class ResponseBodyDeferringAsyncHandler implements AsyncHandler<Response>
   public Response onCompleted() throws IOException {
     try {
       MDC.setContextMap(mdc);
-      // there may have been no body, handle partial response
+      LOGGER.debug("Completed response");
+      // there may have been no a body, handle partial response
       handleIfNecessary();
-      closeOut();
+      if (!lastPartReceived.get()) {
+        closeOut();
+      }
       return null;
     } finally {
       MDC.clear();

--- a/src/main/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandler.java
+++ b/src/main/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandler.java
@@ -340,7 +340,7 @@ public class ResponseBodyDeferringAsyncHandler implements AsyncHandler<Response>
     try {
       MDC.setContextMap(mdc);
       LOGGER.debug("Completed response");
-      // there may have been no a body, handle partial response
+      // there may have been no body, handle partial response
       handleIfNecessary();
       if (!lastPartReceived.get()) {
         // If the last part was not received yet, it won't be received. It's because AHC doesn't call the onBodyPartReceived for

--- a/src/test/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandlerTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandlerTestCase.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -422,6 +421,49 @@ public class ResponseBodyDeferringAsyncHandlerTestCase extends AbstractMuleTestC
     }));
 
     MDC.remove(randomKey);
+  }
+
+  @Test
+  @Issue("W-17617940")
+  public void writeLastPartAsyncAfterOnComplete() throws Exception {
+    // use default timeout for this test
+    clearProperty(READ_TIMEOUT_PROPERTY_NAME);
+    refreshSystemProperties();
+
+    int smallBufferSize = 5;
+
+    CompletableFuture<HttpResponse> future = new CompletableFuture<>();
+    ResponseBodyDeferringAsyncHandler handler =
+        new ResponseBodyDeferringAsyncHandler(future, smallBufferSize, workersExecutor, nonBlockingStreamWriter);
+
+    GrizzlyResponseBodyPart intermediatePart = mockBodyPart(false, "Hel".getBytes());
+    GrizzlyResponseBodyPart lastPart = mockBodyPart(true, "lo world!".getBytes());
+
+    // The writing of the last part will be scheduled because it doesn't fit into the pipe.
+    // As we didn't start the writer thread yet, the onCompleted will be executed before the last part is written.
+    handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS));
+    handler.onBodyPartReceived(intermediatePart);
+    handler.onBodyPartReceived(lastPart);
+    handler.onCompleted();
+
+    // Get the "full" pipe (available = buffer size)
+    InputStream pipe = future.get().getEntity().getContent();
+    assertThat(pipe.available(), is(smallBufferSize));
+
+    // Now we run the writer and consume the pipe asynchronously.
+    StringBuilder responseAsString = new StringBuilder();
+    testExecutor.submit(() -> consumePipe(pipe, responseAsString));
+    workersExecutor.submit(nonBlockingStreamWriter);
+
+    // Eventually, the whole response is consumed from the pipe with no errors.
+    prober.check(new JUnitLambdaProbe(() -> {
+      synchronized (responseAsString) {
+        assertThat(responseAsString.toString(), is("Hello world!"));
+      }
+      return true;
+    }));
+
+    nonBlockingStreamWriter.stop();
   }
 
   private static void consumePipe(InputStream pipe, StringBuilder responseStringBuilder) {

--- a/src/test/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandlerTestCase.java
+++ b/src/test/java/org/mule/service/http/impl/service/client/async/ResponseBodyDeferringAsyncHandlerTestCase.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -334,7 +335,7 @@ public class ResponseBodyDeferringAsyncHandlerTestCase extends AbstractMuleTestC
         new ResponseBodyDeferringAsyncHandler(future, smallBufferSize, workersExecutor, nonBlockingStreamWriter);
 
     GrizzlyResponseBodyPart intermediatePart = mockBodyPart(false, "Hello ".getBytes());
-    GrizzlyResponseBodyPart lastPart = mockBodyPart(true, "world".getBytes());
+    GrizzlyResponseBodyPart lastPart = mockBodyPart(true, "world!".getBytes());
 
     assertThat(handler.onStatusReceived(mock(HttpResponseStatus.class, RETURNS_DEEP_STUBS)), is(CONTINUE));
     assertThat(handler.onBodyPartReceived(intermediatePart), is(CONTINUE));
@@ -368,7 +369,7 @@ public class ResponseBodyDeferringAsyncHandlerTestCase extends AbstractMuleTestC
     // Eventually, the whole response can be consumed from the pipe
     prober.check(new JUnitLambdaProbe(() -> {
       synchronized (responseAsString) {
-        assertThat(responseAsString.toString(), is("Hello world"));
+        assertThat(responseAsString.toString(), is("Hello world!"));
       }
       return true;
     }));


### PR DESCRIPTION
The ResponseBodyDeferringAsyncHandler has some methods that are callbacks called by grizzly AHC when each piece of response is received by the HTTP client.

The relevant methods in this PR are onBodyPartReceived, which is called when some body bytes are received, and onCompleted, that is called after the last byte of body was received.

In W-17048606, we implemented a mechanism to process the body parts in another thread if the data structure where they have to be written is full (and writing synchronously would block the execution). That data structure is a "pipe".
To avoid receiving new body parts concurrently, we also implemented a pause mechanism, that we resume once the part was successfully processed by the other thread. The problem is that the onCompleted method can be called even when the parts reception is paused, because AHC doesn't handle the completion as a new event, but it just calls the callback synchronously after calling onBodyPartReceived, if the body part is the last. The onComplete callback closes the "pipe", so in that situation we would have concurrent calls to pipe.close() and pipe.write().
This change moves the closing of the pipe to the place where we know that we wrote the last part to the pipe (so we don't have a concurrent call).

When grizzly calls onBodyPartReceived, the passed bodyPart indicates if it's the last part or not. When the last part is empty (it's a perfectly valid use case), grizzly has an optimization that avoids calling onBodyPartReceived with the empty part. The boolean lastPartReceived was added to consider that case now that the pipe.close() is not called in the onCompleted() method.